### PR TITLE
[FIX] 게시글 삭제 시 이미지 삭제로 인한 동시성 문제 해결

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/post/entity/Post.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/entity/Post.java
@@ -45,7 +45,7 @@ public class Post extends BaseTimeEntity {
     private List<Content> contents;
 
     @Builder.Default
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "post")
     private List<PostImage> images = new ArrayList<>();
 
     @Builder.Default

--- a/src/main/java/com/server/youthtalktalk/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/service/PostServiceImpl.java
@@ -170,9 +170,15 @@ public class PostServiceImpl implements PostService{
         if(post.getWriter() == null || post.getWriter().getId()!=writer.getId()){ // 작성자가 아닐 경우
             throw new BusinessException(BaseResponseCode.POST_ACCESS_DENIED);
         }
-        imageService.deleteMultiFile(post.getImages().stream().map(PostImage::getImgUrl).toList());
+        // 1. 게시글 이미지 삭제
+        List<String> imageUrls = post.getImages().stream()
+                .map(PostImage::getImgUrl)
+                .toList();
+        imageService.deleteMultiFile(imageUrls);
+        // 2. 게시글 스크랩 삭제
+        scrapRepository.deleteAllByItemIdAndItemType(post.getId().toString(), ItemType.POST);
+        // 3. 게시글 삭제
         postRepository.delete(post);
-        scrapRepository.deleteAllByItemIdAndItemType(post.getId().toString(),ItemType.POST);
         log.info("게시글 삭제 성공, postId = {}", postId);
     }
 

--- a/src/main/java/com/server/youthtalktalk/domain/report/dto/PostReportRequestDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/report/dto/PostReportRequestDto.java
@@ -1,0 +1,2 @@
+package com.server.youthtalktalk.domain.report.dto;public record ReportRequestDto() {
+}

--- a/src/main/java/com/server/youthtalktalk/domain/report/dto/PostReportRequestDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/report/dto/PostReportRequestDto.java
@@ -1,2 +1,0 @@
-package com.server.youthtalktalk.domain.report.dto;public record ReportRequestDto() {
-}


### PR DESCRIPTION
org.springframework.orm.ObjectOptimisticLockingFailureException: Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect)

게시글 삭제 시 동시성 에러 발생.
원인 : imgService.deleteMultiFile 에서 PostImage를 이미 삭제했는데, 그 후 게시글 삭제 시 CasCade.ALL에 의해 PostImage를 또 삭제하려고 접근 
해결 : Post엔티티에서 PostImage는 CasCade.ALL을 적용하지 않음