### PR TITLE
[FEAT] Post, Report 서비스 및 Post 레포지토리 테스트 구현 / 컬럼 타입 변경/ 인기 게시글 조회 쿼리 수정

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/post/entity/Content.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/entity/Content.java
@@ -1,15 +1,26 @@
 package com.server.youthtalktalk.domain.post.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Embeddable
 @Getter
+@NoArgsConstructor
 public class Content {
+    @Column(columnDefinition = "TEXT")
     private String content;
 
     @Enumerated(EnumType.STRING)
     private ContentType type;
+
+    @Builder
+    public Content(String content, ContentType type) {
+        this.content = content;
+        this.type = type;
+    }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/post/entity/Post.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/entity/Post.java
@@ -39,7 +39,6 @@ public class Post extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member writer;
 
-    // 임시 추가
     @ElementCollection
     @CollectionTable(name = "post_contents", joinColumns = @JoinColumn(name = "post_id"))
     private List<Content> contents;
@@ -68,7 +67,6 @@ public class Post extends BaseTimeEntity {
         return PostRepDto.builder()
                 .postId(this.getId())
                 .title(this.getTitle())
-                .content(this.getContent())
                 .contentList(this.getContents())
                 .policyId(this instanceof Review ? ((Review)this).getPolicy().getPolicyId() : null)
                 .policyTitle(this instanceof Review ? ((Review)this).getPolicy().getTitle() : null)

--- a/src/main/java/com/server/youthtalktalk/domain/post/repostiory/PostRepositoryCustom.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/repostiory/PostRepositoryCustom.java
@@ -15,7 +15,7 @@ public interface PostRepositoryCustom {
     /** 모든 게시글 검색 */
     Page<Post> findAllPosts(Member member, Pageable pageable);
     /** 조회수별 게시글 검색 */
-    Page<Post> findAllPostsByView(Member member, Pageable pageable);
+    List<Post> findTopPostsByView(Member member, int top);
     /** 모든 게시글 키워드 검색 */
     Page<Post> findAllPostsByKeyword(Member member, String keyword, Pageable pageable);
     /** 나의 모든 게시글 검색*/
@@ -23,7 +23,7 @@ public interface PostRepositoryCustom {
     /** 카테고리별 리뷰 검색 */
     Page<Post> findAllReviewsByCategory(Member member, List<Category> categories, Pageable pageable);
     /** 카테고리별 리뷰 조회수순 검색 */
-    Page<Post> findAllReviewsByCategoryAndView(Member member, List<Category> categories, Pageable pageable);
+    List<Post> findTopReviewsByCategoryAndView(Member member, List<Category> categories, int top);
     /** 모든 리뷰 키워드 검색 */
     Page<Post> findAllReviewsByKeyword(Member member, String keyword, Pageable pageable);
     /** 스크랩한 게시글 검색*/

--- a/src/main/java/com/server/youthtalktalk/domain/post/repostiory/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/repostiory/PostRepositoryCustomImpl.java
@@ -50,7 +50,6 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                 .leftJoin(block).on(blockJoinWithPost(member))
                 .leftJoin(report).on(reportJoinWithPost(member))
                 .where(postConditionsExcludeReportAndBlocked())
-                .orderBy(post.id.desc())
                 .fetchOne();
 
         return new PageImpl<>(posts, pageable, total == null ? 0 : total);
@@ -58,27 +57,17 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
 
     /** 조회수별 게시글 검색 */
     @Override
-    public Page<Post> findAllPostsByView(Member member, Pageable pageable) {
+    public List<Post> findTopPostsByView(Member member, int top) {
         List<Post> posts = queryFactory
                 .selectFrom(post)
                 .leftJoin(block).on(blockJoinWithPost(member))
                 .leftJoin(report).on(reportJoinWithPost(member))
                 .where(postConditionsExcludeReportAndBlocked())
                 .orderBy(post.view.desc(), post.id.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .limit(top)
                 .fetch();
 
-        Long total = queryFactory
-                .select(post.count())
-                .from(post)
-                .leftJoin(block).on(blockJoinWithPost(member))
-                .leftJoin(report).on(reportJoinWithPost(member))
-                .where(postConditionsExcludeReportAndBlocked())
-                .orderBy(post.view.desc(), post.id.desc())
-                .fetchOne();
-
-        return new PageImpl<>(posts, pageable, total == null ? 0 : total);
+        return posts;
     }
 
     /** 모든 게시글 키워드 검색 */
@@ -103,7 +92,6 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                 .leftJoin(block).on(blockJoinWithPost(member))
                 .leftJoin(report).on(reportJoinWithPost(member))
                 .where(postConditionsExcludeReportAndBlocked().and(deleteSpaces.like(keywordWithoutSpaces)))
-                .orderBy(post.id.desc())
                 .fetchOne();
 
         return new PageImpl<>(posts, pageable, total == null ? 0 : total);
@@ -124,7 +112,6 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                 .select(post.count())
                 .from(post)
                 .where(post.writer.eq(writer))
-                .orderBy(post.id.desc())
                 .fetchOne();
 
         return new PageImpl<>(posts, pageable, total == null ? 0 : total);
@@ -151,14 +138,13 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                 .leftJoin(report).on(reportJoinWithPost(member))
                 .where(reviewConditionsExcludeReportAndBlocked()
                         .and(JPAExpressions.treat(post, QReview.class).policy.category.in(categories)))
-                .orderBy(post.id.desc())
                 .fetchOne();
 
         return new PageImpl<>(reviews, pageable, total == null ? 0 : total);
     }
 
     @Override
-    public Page<Post> findAllReviewsByCategoryAndView(Member member, List<Category> categories, Pageable pageable) {
+    public List<Post> findTopReviewsByCategoryAndView(Member member, List<Category> categories, int top) {
         List<Post> reviews = queryFactory
                 .selectFrom(post)
                 .leftJoin(block).on(blockJoinWithPost(member))
@@ -166,21 +152,10 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                 .where(reviewConditionsExcludeReportAndBlocked()
                         .and(JPAExpressions.treat(post, QReview.class).policy.category.in(categories)))
                 .orderBy(post.view.desc(), post.id.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .limit(top)
                 .fetch();
 
-        Long total = queryFactory
-                .select(post.count())
-                .from(post)
-                .leftJoin(block).on(blockJoinWithPost(member))
-                .leftJoin(report).on(reportJoinWithPost(member))
-                .where(reviewConditionsExcludeReportAndBlocked()
-                        .and(JPAExpressions.treat(post, QReview.class).policy.category.in(categories)))
-                .orderBy(post.view.desc(), post.id.desc())
-                .fetchOne();
-
-        return new PageImpl<>(reviews, pageable, total == null ? 0 : total);
+        return reviews;
     }
 
     /** 모든 리뷰 키워드 검색 */
@@ -207,7 +182,6 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                 .leftJoin(report).on(reportJoinWithPost(member))
                 .where(reviewConditionsExcludeReportAndBlocked()
                         .and(deleteSpaces.like(keywordWithoutSpaces)))
-                .orderBy(post.id.desc())
                 .fetchOne();
 
         return new PageImpl<>(reviews, pageable, total == null ? 0 : total);
@@ -234,7 +208,6 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                 .leftJoin(report).on(reportJoinWithPost(member))
                 .join(scrap).on(post.id.stringValue().eq(scrap.itemId))
                 .where(report.id.isNull().and(block.id.isNull()).and(scrap.member.eq(member)))
-                .orderBy(scrap.id.desc())
                 .fetchOne();
 
         return new PageImpl<>(posts, pageable, total == null ? 0 : total);

--- a/src/main/java/com/server/youthtalktalk/domain/post/service/PostReadServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/service/PostReadServiceImpl.java
@@ -43,7 +43,7 @@ public class PostReadServiceImpl implements PostReadService {
     private final ReportRepository reportRepository;
     private final BlockRepository blockRepository;
     private final PostRepositoryCustom postRepositoryCustom;
-
+    private static final int TOP = 5;
     /** 게시글, 리뷰 상세 조회 */
     @Override
     @Transactional
@@ -67,10 +67,10 @@ public class PostReadServiceImpl implements PostReadService {
     @Transactional
     public PostListRepDto getAllPost(Pageable pageable, Member member) {
         Pageable pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-        Page<Post> postPopularPage = postRepositoryCustom.findAllPostsByView(member, PageRequest.of(0, 5)); // 상위 5개만
+        List<Post> popularPostList = postRepositoryCustom.findTopPostsByView(member, TOP); // 상위 5개만
         Page<Post> postPage = postRepositoryCustom.findAllPosts(member, pageRequest);
 
-        return toPostListRepDto(postPopularPage.getContent(),postPage.getContent(),member);
+        return toPostListRepDto(popularPostList, postPage.getContent(),member);
     }
 
     /** 리뷰 카테고리별 전체 조회 */
@@ -78,10 +78,10 @@ public class PostReadServiceImpl implements PostReadService {
     @Transactional
     public PostListRepDto getAllReviewByCategory(Pageable pageable, List<Category> categories, Member member) {
         Pageable pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-        Page<Post> reviewPopularPage = postRepositoryCustom.findAllReviewsByCategoryAndView(member, categories,PageRequest.of(0, 5)); // 상위 5개만
-        Page<Post> reviewPage = postRepositoryCustom.findAllReviewsByCategory(member, categories,pageRequest);
+        List<Post> popularReviewList = postRepositoryCustom.findTopReviewsByCategoryAndView(member, categories, TOP); // 상위 5개만
+        Page<Post> reviewPage = postRepositoryCustom.findAllReviewsByCategory(member, categories, pageRequest);
 
-        return toPostListRepDto(reviewPopularPage.getContent(),reviewPage.getContent(),member);
+        return toPostListRepDto(popularReviewList, reviewPage.getContent(),member);
     }
 
     /** 나의 게시글, 리뷰 전체 조회 */
@@ -140,7 +140,6 @@ public class PostReadServiceImpl implements PostReadService {
         return PostListDto.builder()
                 .postId(post.getId())
                 .title(post.getTitle())
-                .content(post.getContent())
                 .writerId(post.getWriter() == null ? null : post.getWriter().getId())
                 .policyId(post instanceof Review ? ((Review) post).getPolicy().getPolicyId() : null)
                 .policyTitle(post instanceof Review ? ((Review)post).getPolicy().getTitle() : null )
@@ -156,7 +155,6 @@ public class PostReadServiceImpl implements PostReadService {
         return ScrapPostListDto.builder()
                 .postId(post.getId())
                 .title(post.getTitle())
-                .content(post.getContent())
                 .writerId(post.getWriter() == null ? null : post.getWriter().getId())
                 .policyId(post instanceof Review ? ((Review) post).getPolicy().getPolicyId() : null)
                 .policyTitle(post instanceof Review ? ((Review)post).getPolicy().getTitle() : null )

--- a/src/main/java/com/server/youthtalktalk/domain/post/service/PostService.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/service/PostService.java
@@ -1,18 +1,17 @@
 package com.server.youthtalktalk.domain.post.service;
 
+import com.server.youthtalktalk.domain.post.entity.Post;
 import com.server.youthtalktalk.domain.scrap.entity.Scrap;
 import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.post.dto.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
 
 public interface PostService {
-    PostRepDto createPost(PostCreateReqDto postCreateReqDto, List<MultipartFile> fileList, Member writer) throws IOException;
-    PostRepDto createPostTest(PostCreateTestReqDto postCreateTestReqDto, Member writer) throws IOException;
-    PostRepDto updatePost(Long postId, PostUpdateReqDto postUpdateReqDto, List<MultipartFile> fileList, Member writer) throws IOException;
-    PostRepDto updatePostTest(Long postId, PostUpdateReqTestDto postUpdateReqDto, Member writer) throws  IOException;
+    PostRepDto createPost(PostCreateReqDto postCreateReqDto, Member writer) throws IOException;
+    PostRepDto updatePost(Long postId, PostUpdateReqDto postUpdateReqDto, Member writer) throws  IOException;
     void deletePost(Long postId, Member writer);
     Scrap scrapPost(Long postId, Member member);
+    List<String> extractImageUrl(Post post);
 }

--- a/src/test/java/com/server/youthtalktalk/config/TestQueryDSLConfig.java
+++ b/src/test/java/com/server/youthtalktalk/config/TestQueryDSLConfig.java
@@ -1,0 +1,25 @@
+package com.server.youthtalktalk.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.server.youthtalktalk.domain.post.repostiory.PostRepositoryCustom;
+import com.server.youthtalktalk.domain.post.repostiory.PostRepositoryCustomImpl;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestQueryDSLConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+    @Bean
+    public PostRepositoryCustom postRepositoryCustom(){
+        return new PostRepositoryCustomImpl(jpaQueryFactory());
+    }
+}

--- a/src/test/java/com/server/youthtalktalk/repository/post/PostRepositoryCustomTest.java
+++ b/src/test/java/com/server/youthtalktalk/repository/post/PostRepositoryCustomTest.java
@@ -1,0 +1,139 @@
+package com.server.youthtalktalk.repository.post;
+
+import com.server.youthtalktalk.config.TestQueryDSLConfig;
+import com.server.youthtalktalk.domain.member.entity.Member;
+import com.server.youthtalktalk.domain.member.entity.Role;
+import com.server.youthtalktalk.domain.member.repository.BlockRepository;
+import com.server.youthtalktalk.domain.member.repository.MemberRepository;
+import com.server.youthtalktalk.domain.policy.entity.Category;
+import com.server.youthtalktalk.domain.policy.entity.Policy;
+import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
+import com.server.youthtalktalk.domain.post.entity.Content;
+import com.server.youthtalktalk.domain.post.entity.ContentType;
+import com.server.youthtalktalk.domain.post.entity.Post;
+import com.server.youthtalktalk.domain.post.entity.Review;
+import com.server.youthtalktalk.domain.post.repostiory.PostRepository;
+import com.server.youthtalktalk.domain.post.repostiory.PostRepositoryCustom;
+import com.server.youthtalktalk.domain.post.repostiory.PostRepositoryCustomImpl;
+import com.server.youthtalktalk.domain.report.repository.ReportRepository;
+import com.server.youthtalktalk.domain.scrap.repository.ScrapRepository;
+import com.server.youthtalktalk.global.config.QueryDSLConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(TestQueryDSLConfig.class)
+public class PostRepositoryCustomTest {
+    @Autowired
+    private PostRepositoryCustom postRepositoryCustom;
+    @Autowired
+    private PostRepository postRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private PolicyRepository policyRepository;
+    @Autowired
+    private ScrapRepository scrapRepository;
+    @Autowired
+    private ReportRepository reportRepository;
+    @Autowired
+    private BlockRepository blockRepository;
+
+    private static final long LEN = 2;
+    private static final int TOP = 5;
+    Member member1, member2;
+    Policy policy;
+    List<Post> postList = new ArrayList<>();
+
+    @BeforeEach
+    void init(){
+        member1 = memberRepository.save(Member.builder()
+                .id(1L)
+                .username("member1")
+                .role(Role.USER)
+                .build());
+        member2 = memberRepository.save(Member.builder()
+                .id(2L)
+                .username("member2")
+                .role(Role.USER)
+                .build());
+
+        this.policy = policyRepository.save(Policy.builder()
+                .policyId("policyId")
+                .title("policy1")
+                .category(Category.JOB)
+                .build());
+
+        List<Content> contentList = List.of(Content.builder().content("content").type(ContentType.TEXT).build());
+        for(long i = 1; i <= LEN; i++) {
+            postList.add(postRepository.save(Post.builder()
+                .title("post" + i)
+                .writer(member1)
+                .contents(contentList)
+                .build()));
+
+            postList.add(postRepository.save(Review.builder()
+                .title("review" + i)
+                .writer(member2)
+                .policy(policy)
+                .contents(contentList)
+                .build()));
+        }
+    }
+
+    @Test
+    @DisplayName("전체 게시글 조회 성공")
+    void successFindAllPosts(){
+        // Given
+        Pageable pageable1 = PageRequest.of(0, 1);
+        Pageable pageable2 = PageRequest.of(1, 1);
+
+        // When
+        Page<Post> posts1 = postRepositoryCustom.findAllPosts(member1, pageable1);
+        Page<Post> posts2 = postRepositoryCustom.findAllPosts(member1, pageable2);
+        Post post1 = posts1.getContent().get(0);
+        // Then
+        assertThat(posts1.getSize()).isEqualTo(1);
+        assertThat(posts2.getSize()).isEqualTo(1);
+        assertThat(posts1.getTotalElements()).isEqualTo(2);
+        assertThat(posts2.getTotalElements()).isEqualTo(2);
+
+        assertThat(post1.getId()).isEqualTo(postList.get(2).getId());
+        assertThat(post1.getTitle()).isEqualTo(postList.get(2).getTitle());
+        assertThat(post1.getWriter()).isEqualTo(member1);
+        assertThat(post1.getContents()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("Top 조회수 인기글 조회 성공")
+    void successFindTopPostsByView(){
+        // Given
+        Post post1 = postRepository.save(Post.builder().title("post1").view(3L).build());
+        Post post2 = postRepository.save(Post.builder().title("post2").view(2L).build());
+        Post post3 = postRepository.save(Post.builder().title("post3").view(2L).build());
+        Post post4 = postRepository.save(Post.builder().title("post4").view(1L).build());
+
+        // When
+        List<Post> posts = postRepositoryCustom.findTopPostsByView(member1, TOP);
+        Post[] arr = posts.toArray(new Post[0]);
+        // Then
+        assertThat(arr[0].getId()).isEqualTo(post1.getId());
+        assertThat(arr[1].getId()).isEqualTo(post3.getId());
+        assertThat(arr[2].getId()).isEqualTo(post2.getId());
+        assertThat(arr[3].getId()).isEqualTo(post4.getId());
+    }
+}

--- a/src/test/java/com/server/youthtalktalk/service/post/PostReadServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/post/PostReadServiceTest.java
@@ -1,92 +1,469 @@
 package com.server.youthtalktalk.service.post;
 
 import com.server.youthtalktalk.domain.ItemType;
+import com.server.youthtalktalk.domain.member.repository.BlockRepository;
+import com.server.youthtalktalk.domain.policy.entity.Category;
+import com.server.youthtalktalk.domain.policy.entity.Policy;
+import com.server.youthtalktalk.domain.post.dto.PostListRepDto;
+import com.server.youthtalktalk.domain.post.entity.Content;
+import com.server.youthtalktalk.domain.post.entity.ContentType;
+import com.server.youthtalktalk.domain.post.entity.Review;
 import com.server.youthtalktalk.domain.post.repostiory.PostRepositoryCustom;
-import com.server.youthtalktalk.domain.scrap.entity.Scrap;
+import com.server.youthtalktalk.domain.post.service.PostReadServiceImpl;
+import com.server.youthtalktalk.domain.report.repository.ReportRepository;
 import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.member.entity.Role;
 import com.server.youthtalktalk.domain.post.entity.Post;
 import com.server.youthtalktalk.domain.post.dto.PostRepDto;
-import com.server.youthtalktalk.domain.member.repository.MemberRepository;
-import com.server.youthtalktalk.domain.post.service.PostReadService;
 import com.server.youthtalktalk.domain.post.repostiory.PostRepository;
+import com.server.youthtalktalk.domain.scrap.entity.Scrap;
 import com.server.youthtalktalk.domain.scrap.repository.ScrapRepository;
-import jakarta.persistence.EntityManager;
-import org.junit.jupiter.api.BeforeEach;
+import com.server.youthtalktalk.global.response.BaseResponseCode;
+import com.server.youthtalktalk.global.response.exception.InvalidValueException;
+import com.server.youthtalktalk.global.response.exception.post.BlockedMemberPostAccessDeniedException;
+import com.server.youthtalktalk.global.response.exception.post.PostNotFoundException;
+import com.server.youthtalktalk.global.response.exception.post.ReportedPostAccessDeniedException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.server.youthtalktalk.domain.post.dto.PostListRepDto.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
-@SpringBootTest
-@Transactional
+@ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
 public class PostReadServiceTest {
-    @Autowired
-    private PostReadService postReadService;
-    @Autowired
-    private EntityManager em;
-
-    private Member member;
-    private Post post;
-    @Autowired
+    @InjectMocks
+    private PostReadServiceImpl postReadService;
+    @Mock
     private PostRepository postRepository;
-    @Autowired
-    private MemberRepository memberRepository;
-    @Autowired
+    @Mock
     private ScrapRepository scrapRepository;
-    @Autowired
+    @Mock
+    private BlockRepository blockRepository;
+    @Mock
+    private ReportRepository reportRepository;
+    @Mock
     private PostRepositoryCustom postRepositoryCustom;
 
-    private void clear(){
-        em.flush();
-        em.clear();
-    }
-
-    @BeforeEach
-    void init(){
-        this.member = memberRepository.save(Member.builder()
-                        .username("testPost")
-                        .role(Role.USER)
-                        .build());
-        this.post = postRepository.save(Post.builder()
-                        .title("test")
-                        .view(0L)
-                        .content("content")
-                        .writer(member)
-                        .build());
-        clear();
-    }
+    private static final int LEN = 5;
+    private static final int TOP = 5;
 
     @Test
-    @DisplayName("게시글 상세 조회")
-    void getPostByIdTest(){
-        PostRepDto postRepDto = postReadService.getPostById(post.getId(),member);
+    @DisplayName("게시글 상세 조회 성공")
+    void successGetPostById(){
+        Member member1 = createMember("member1",1L);
+        Member member2 = createMember("member2",2L);
+        // Given
+        Post post = Post.builder()
+                .title("post")
+                .id(1L)
+                .contents(new ArrayList<>(List.of(createContent())))
+                .view(1L)
+                .writer(member2)
+                .build();
+        when(postRepository.findById(post.getId())).thenReturn(Optional.of(post));
+        when(reportRepository.existsByPostAndReporter(post,member1)).thenReturn(false);
+        when(blockRepository.existsByMemberAndBlockedMember(member1, post.getWriter())).thenReturn(false);
+        when(scrapRepository.existsByMemberIdAndItemIdAndItemType(member1.getId(),post.getId().toString(), ItemType.POST))
+                .thenReturn(true);
+        // When
+        PostRepDto postRepDto = postReadService.getPostById(post.getId(),member1);
+        // Then
         assertThat(postRepDto.getPostId()).isEqualTo(post.getId());
+        assertThat(postRepDto.getTitle()).isEqualTo(post.getTitle());
+        assertThat(postRepDto.getView()).isEqualTo(1L);
+        assertThat(postRepDto.getWriterId()).isEqualTo(member2.getId());
+        assertThat(postRepDto.isScrap()).isTrue();
+        assertThat(postRepDto.getContentList().size()).isEqualTo(1);
+
+        verify(postRepository).findById(post.getId());
+        verify(reportRepository).existsByPostAndReporter(post,member1);
+        verify(blockRepository).existsByMemberAndBlockedMember(member1,post.getWriter());
+        verify(scrapRepository).existsByMemberIdAndItemIdAndItemType(member1.getId(),post.getId().toString(), ItemType.POST);
     }
 
     @Test
-    @DisplayName("내가 작성한 게시글 조회")
-    void getAllMyPostTest(){
-        Pageable pageable = PageRequest.of(0,10);
-        assertThat(postReadService.getAllMyPost(pageable,member)).hasSize(1);
+    @DisplayName("존재하지 않는 게시물 조회 실패")
+    void failGetPostByIdIfNotExist(){
+        Member member1 = createMember("member1",1L);
+        assertThatThrownBy(() -> postReadService.getPostById(Long.MAX_VALUE,member1))
+                .isInstanceOf(PostNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("신고한 게시글 조회 실패")
+    void failGetPostByIdIfReportedPost(){
+        // Given
+        Post post = Post.builder()
+                        .id(1L)
+                        .build();
+        Member member1 = Member.builder().build();
+        when(postRepository.findById(post.getId())).thenReturn(Optional.of(post));
+        when(reportRepository.existsByPostAndReporter(post, member1)).thenReturn(true);
+
+        // When, Then
+        assertThatThrownBy(() -> postReadService.getPostById(post.getId(),member1))
+                .isInstanceOf(ReportedPostAccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("차단한 유저의 게시글 조회 실패")
+    void failGetPostByIdIfBlockedWriter(){
+        // Given
+        Post post = Post.builder()
+                .id(1L)
+                .build();
+        Member member1 = Member.builder().build();
+        when(postRepository.findById(post.getId())).thenReturn(Optional.of(post));
+        when(reportRepository.existsByPostAndReporter(post, member1)).thenReturn(false);
+        when(blockRepository.existsByMemberAndBlockedMember(member1, post.getWriter())).thenReturn(true);
+        // When, Then
+        assertThatThrownBy(() -> postReadService.getPostById(post.getId(),member1))
+                .isInstanceOf(BlockedMemberPostAccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("자유 게시글 PostListDto 변환 성공")
+    void successFreePostToPostDto(){
+        // Given
+        Member member = createMember("member",1L);
+        Post post = createPost("post",1L, member, 10L);
+        when(scrapRepository.existsByMemberIdAndItemIdAndItemType(member.getId(),post.getId().toString(),ItemType.POST))
+                .thenReturn(true);
+        when(scrapRepository.findAllByItemIdAndItemType(post.getId().toString(), ItemType.POST))
+                .thenReturn(new ArrayList<>());
+        // When
+        PostListDto postListDto = postReadService.toPostDto(post, member);
+        // Then
+        assertThat(postListDto.getPostId()).isEqualTo(1L);
+        assertThat(postListDto.getTitle()).isEqualTo("post");
+        assertThat(postListDto.getWriterId()).isEqualTo(1L);
+        assertThat(postListDto.isScrap()).isTrue();
+        assertThat(postListDto.getPolicyId()).isNull();
+        assertThat(postListDto.getPolicyTitle()).isNull();
+        assertThat(postListDto.getComments()).isEqualTo(0);
+
+        verify(scrapRepository).existsByMemberIdAndItemIdAndItemType(member.getId(),post.getId().toString(),ItemType.POST);
+        verify(scrapRepository).findAllByItemIdAndItemType(post.getId().toString(), ItemType.POST);
+    }
+
+    @Test
+    @DisplayName("리뷰 PostListDto 변환 성공")
+    void successReviewToPostDto(){
+        // Given
+        Member member = createMember("member",1L);
+        Policy policy = Policy.builder()
+                .policyId("policyId")
+                .title("policy")
+                .build();
+        Review review = Review.builder()
+                .id(1L)
+                .postComments(new ArrayList<>())
+                .policy(policy)
+                .title("review")
+                .writer(member)
+                .build();
+        when(scrapRepository.existsByMemberIdAndItemIdAndItemType(member.getId(),review.getId().toString(),ItemType.POST))
+                .thenReturn(true);
+        when(scrapRepository.findAllByItemIdAndItemType(review.getId().toString(), ItemType.POST))
+                .thenReturn(new ArrayList<>());
+        // When
+        PostListDto postListDto = postReadService.toPostDto(review, member);
+        // Then
+        assertThat(postListDto.getPostId()).isEqualTo(1L);
+        assertThat(postListDto.getTitle()).isEqualTo("review");
+        assertThat(postListDto.getWriterId()).isEqualTo(member.getId());
+        assertThat(postListDto.isScrap()).isTrue();
+        assertThat(postListDto.getPolicyId()).isEqualTo("policyId");
+        assertThat(postListDto.getPolicyTitle()).isEqualTo("policy");
+        assertThat(postListDto.getComments()).isEqualTo(0);
+
+        verify(scrapRepository).existsByMemberIdAndItemIdAndItemType(member.getId(),review.getId().toString(),ItemType.POST);
+        verify(scrapRepository).findAllByItemIdAndItemType(review.getId().toString(), ItemType.POST);
+    }
+
+    @Test
+    @DisplayName("게시글 전체 조회 성공")
+    void successGetAllPost(){
+        // Given
+        Member member = createMember("member",1L);
+        List<Post> posts = new ArrayList<>();
+        for(long i = 0; i < LEN; i++){
+            posts.add(createPost("post"+i, i, member, LEN - i));
+        }
+        int pageSize = 3;
+        Pageable pageable1 = PageRequest.of(0, pageSize);
+        Pageable pageable2 = PageRequest.of(1, pageSize);
+
+        when(postRepositoryCustom.findTopPostsByView(member, TOP)) // 인기순(조회수)
+                .thenReturn(posts);
+        when(postRepositoryCustom.findAllPosts(member, pageable1))
+                .thenReturn(convertListToPage(posts, pageable1));
+        when(postRepositoryCustom.findAllPosts(member, pageable2))
+                .thenReturn(convertListToPage(posts, pageable2));
+        // When
+        PostListRepDto postListRepDto1 = postReadService.getAllPost(pageable1, member);
+        PostListRepDto postListRepDto2 = postReadService.getAllPost(pageable2, member);
+        // Then
+        assertThat(postListRepDto1.getTop5_posts().get(0).getTitle()).isEqualTo("post0"); // 인기순 (조회수)
+        assertThat(postListRepDto1.getTop5_posts().get(1).getTitle()).isEqualTo("post1");
+        assertThat(postListRepDto1.getTop5_posts()).hasSize(LEN);
+
+        for(int i = 0; i < pageSize; i++){
+            assertThat(postListRepDto1.getOther_posts().get(i).getTitle()).isEqualTo("post"+i);
+        }
+        assertThat(postListRepDto1.getOther_posts()).hasSize(pageSize);
+        assertThat(postListRepDto2.getOther_posts()).hasSize(LEN - pageSize);
+
+        verify(postRepositoryCustom, times(2)).findTopPostsByView(member, TOP);
+        verify(postRepositoryCustom).findAllPosts(member, pageable1);
+        verify(postRepositoryCustom).findAllPosts(member, pageable2);
+    }
+
+    @Test
+    @DisplayName("카테고리별 리뷰 전체 조회")
+    void successGetAllReviewByCategory(){
+        // Given
+        Member member = createMember("member",1L);
+        Policy policy = Policy.builder()
+                .policyId("policyId")
+                .title("policy")
+                .category(Category.JOB)
+                .build();
+        List<Post> posts = new ArrayList<>();
+        for(long i = 0; i < LEN; i++){
+            Review review = Review.builder()
+                    .id(1 + i)
+                    .postComments(new ArrayList<>())
+                    .policy(policy)
+                    .view(LEN - i)
+                    .title("review" + i + 1)
+                    .writer(member)
+                    .build();
+            posts.add(review);
+        }
+
+        List<Category> categories = new ArrayList<>(List.of(Category.JOB));
+        Pageable pageable = PageRequest.of(0, LEN);
+
+        when(postRepositoryCustom.findTopReviewsByCategoryAndView(member, categories, TOP))
+                .thenReturn(posts);
+        when(postRepositoryCustom.findAllReviewsByCategory(member, categories, pageable))
+                .thenReturn(convertListToPage(posts, pageable));
+        // When
+        PostListRepDto postListRepDto = postReadService.getAllReviewByCategory(pageable, categories, member);
+        // Then
+        assertThat(postListRepDto.getOther_posts()).hasSize(LEN);
+        assertThat(postListRepDto.getOther_posts().get(0).getPolicyTitle()).isEqualTo(policy.getTitle());
+        assertThat(postListRepDto.getOther_posts().get(0).getPolicyId()).isEqualTo(policy.getPolicyId());
+
+        verify(postRepositoryCustom).findTopReviewsByCategoryAndView(member, categories, TOP);
+        verify(postRepositoryCustom).findAllReviewsByCategory(member, categories, pageable);
+    }
+
+    @Test
+    @DisplayName("내가 작성한 게시글 조회 성공")
+    void successGetAllMyPostTest(){
+        // Given
+        Member member = createMember("member",1L);
+        List<Post> posts = new ArrayList<>();
+        for(long i = 0; i < LEN; i++){
+            posts.add(createPost("post"+i, i, member, LEN - i));
+        }
+        Pageable pageable = PageRequest.of(0, LEN);
+        when(postRepositoryCustom.findAllPostsByWriter(pageable, member)).thenReturn(convertListToPage(posts, pageable));
+        // When
+        List<PostListDto> myPosts = postReadService.getAllMyPost(pageable, member);
+        // Then
+        assertThat(myPosts).hasSize(LEN);
+        assertThat(myPosts.get(0).getWriterId()).isEqualTo(member.getId());
+
+        verify(postRepositoryCustom).findAllPostsByWriter(pageable, member);
+    }
+
+    @Test
+    @DisplayName("키워드별 전체 게시글, 리뷰 조회 성공")
+    void successGetAllPostByKeyword(){
+        // Given
+        Member member = createMember("member",1L);
+        Policy policy = Policy.builder()
+                .policyId("policyId")
+                .title("policy")
+                .category(Category.JOB)
+                .build();
+        List<Post> posts = new ArrayList<>(List.of(createPost("testPost",1L, member, 1L)));
+        List<Post> reviews = new ArrayList<>(List.of(Review.builder()
+                .id(2L)
+                .title("testReview")
+                .policy(policy)
+                .build()));
+
+        Pageable pageable = PageRequest.of(0, 1);
+        String keyword = "test";
+        when(postRepositoryCustom.findAllPostsByKeyword(member, keyword, pageable))
+                .thenReturn(convertListToPage(posts, pageable));
+        when(postRepositoryCustom.findAllReviewsByKeyword(member, keyword, pageable))
+                .thenReturn(convertListToPage(reviews, pageable));
+        // When
+        PostListResponse postsByKeyword = postReadService.getAllPostByKeyword(pageable, "post", keyword, member);
+        PostListResponse reviewsByKeyword = postReadService.getAllPostByKeyword(pageable, "review", keyword, member);
+        // Then
+        assertThat(postsByKeyword.getPage()).isEqualTo(pageable.getPageNumber());
+        assertThat(postsByKeyword.getPosts()).hasSize(1);
+        assertThat(postsByKeyword.getTotal()).isEqualTo(1);
+        assertThat(postsByKeyword.getPosts().get(0).getTitle()).contains(keyword);
+
+        assertThat(reviewsByKeyword.getPage()).isEqualTo(pageable.getPageNumber());
+        assertThat(reviewsByKeyword.getPosts()).hasSize(1);
+        assertThat(reviewsByKeyword.getTotal()).isEqualTo(1);
+        assertThat(reviewsByKeyword.getPosts().get(0).getPolicyId()).isEqualTo(policy.getPolicyId());
+        assertThat(reviewsByKeyword.getPosts().get(0).getTitle()).contains(keyword);
+
+        verify(postRepositoryCustom).findAllPostsByKeyword(member, keyword, pageable);
+        verify(postRepositoryCustom).findAllReviewsByKeyword(member, keyword, pageable);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 타입 파라미터로 인한 키워드별 전체 게시글, 리뷰 조회 실패")
+    void failGetAllPostByKeywordIfInvalidType() {
+        // Given
+        Member member = createMember("member",1L);
+        String type = "invalidType";
+        Pageable pageable = PageRequest.of(0, 1);
+        // When, Then
+        assertThatThrownBy(() -> postReadService.getAllPostByKeyword(pageable, type, "test", member))
+                .isInstanceOf(InvalidValueException.class)
+                .hasMessage(BaseResponseCode.INVALID_INPUT_VALUE.getMessage());
     }
 
     @Test
     @DisplayName("내가 스크랩한 게시글 조회")
-    void getScrapPostListTest(){
-        scrapRepository.save(Scrap.builder()
-                        .itemId(post.getId().toString())
-                        .itemType(ItemType.POST)
-                        .member(member)
-                        .build());
-        Pageable pageable = PageRequest.of(0,10);
-        assertThat(postReadService.getScrapPostList(pageable,member).size()).isEqualTo(1);
+    void successGetScrapPostList(){
+        // Given
+        Member member = createMember("member",1L);
+        List<Post> posts = new ArrayList<>();
+        for(long i = 0; i < LEN; i++){
+            posts.add(createPost("post"+i, i, member, LEN - i));
+        }
+
+        Pageable pageable = PageRequest.of(0, LEN);
+        when(postRepositoryCustom.findAllByScrap(member, pageable)).thenReturn(convertListToPage(posts, pageable));
+        for(Post post : posts){
+            Scrap scrap = Scrap.builder()
+                    .member(member)
+                    .itemType(ItemType.POST)
+                    .itemId(post.getId().toString())
+                    .build();
+            when(scrapRepository.findByMemberAndItemIdAndItemType(member,post.getId().toString(),ItemType.POST))
+                    .thenReturn(Optional.of(scrap));
+            when(scrapRepository.findAllByItemIdAndItemType(post.getId().toString(), ItemType.POST))
+                    .thenReturn(new ArrayList<>(List.of(scrap)));
+        }
+
+        // When
+        List<ScrapPostListDto> scrapPostList = postReadService.getScrapPostList(pageable, member);
+        // Then
+        ScrapPostListDto first = scrapPostList.get(0);
+        assertThat(scrapPostList).hasSize(LEN);
+        assertThat(first.getPostId()).isEqualTo(posts.get(0).getId());
+        assertThat(first.getTitle()).isEqualTo(posts.get(0).getTitle());
+        assertThat(first.getScraps()).isEqualTo(1);
+        assertThat(first.getWriterId()).isEqualTo(member.getId());
+        assertThat(first.getPolicyTitle()).isNull();
+        assertThat(first.getPolicyId()).isNull();
+
+        verify(postRepositoryCustom).findAllByScrap(member, pageable);
+    }
+
+    @Test
+    @DisplayName("내가 스크랩한 후기 조회")
+    void successGetScrapReviewList(){
+        // Given
+        Member member = createMember("member",1L);
+        Policy policy = Policy.builder()
+                .policyId("policyId")
+                .title("policy")
+                .category(Category.JOB)
+                .build();
+        List<Post> reviews = new ArrayList<>(List.of(Review.builder()
+                .id(2L)
+                .title("testReview")
+                .policy(policy)
+                .build()));
+
+
+        Pageable pageable = PageRequest.of(0, 1);
+        when(postRepositoryCustom.findAllByScrap(member, pageable)).thenReturn(convertListToPage(reviews, pageable));
+        for(Post post : reviews){
+            Scrap scrap = Scrap.builder()
+                    .member(member)
+                    .itemType(ItemType.POST)
+                    .itemId(post.getId().toString())
+                    .build();
+            when(scrapRepository.findByMemberAndItemIdAndItemType(member,post.getId().toString(),ItemType.POST))
+                    .thenReturn(Optional.of(scrap));
+            when(scrapRepository.findAllByItemIdAndItemType(post.getId().toString(), ItemType.POST))
+                    .thenReturn(new ArrayList<>(List.of(scrap)));
+        }
+
+        // When
+        List<ScrapPostListDto> scrapPostList = postReadService.getScrapPostList(pageable, member);
+        // Then
+        ScrapPostListDto first = scrapPostList.get(0);
+        assertThat(scrapPostList).hasSize(1);
+        assertThat(first.getScraps()).isEqualTo(1);
+        assertThat(first.getPolicyTitle()).isEqualTo(policy.getTitle());
+        assertThat(first.getPolicyId()).isEqualTo(policy.getPolicyId());
+
+        verify(postRepositoryCustom).findAllByScrap(member, pageable);
+    }
+
+    private Post createPost(String title, Long id, Member writer, Long view){
+        return Post.builder()
+                .id(id)
+                .contents(new ArrayList<>(List.of(createContent())))
+                .writer(writer)
+                .view(view)
+                .title(title)
+                .postComments(new ArrayList<>())
+                .build();
+    }
+
+    private Member createMember(String name, Long id){
+        return Member.builder()
+                .role(Role.USER)
+                .username(name)
+                .id(id)
+                .build();
+    }
+
+    private Content createContent(){
+        return Content.builder()
+                .content("content")
+                .type(ContentType.TEXT)
+                .build();
+    }
+
+    private Page<Post> convertListToPage(List<Post> posts, Pageable pageable) {
+        int start = (int) pageable.getOffset();
+        System.out.println(start);
+        int end = Math.min((start + pageable.getPageSize()), posts.size());
+
+        List<Post> subList = posts.subList(start, end);
+        return new PageImpl<>(subList, pageable, posts.size());
     }
 }

--- a/src/test/java/com/server/youthtalktalk/service/post/PostServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/post/PostServiceTest.java
@@ -1,19 +1,31 @@
 package com.server.youthtalktalk.service.post;
 
 import com.server.youthtalktalk.domain.ItemType;
+import com.server.youthtalktalk.domain.image.entity.PostImage;
+import com.server.youthtalktalk.domain.image.repository.ImageRepository;
 import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.member.entity.Role;
 import com.server.youthtalktalk.domain.policy.entity.Category;
 import com.server.youthtalktalk.domain.policy.entity.Policy;
+import com.server.youthtalktalk.domain.policy.entity.Region;
+import com.server.youthtalktalk.domain.post.dto.PostCreateReqDto;
+import com.server.youthtalktalk.domain.post.dto.PostUpdateReqDto;
+import com.server.youthtalktalk.domain.post.entity.Content;
+import com.server.youthtalktalk.domain.post.entity.ContentType;
 import com.server.youthtalktalk.domain.post.entity.Post;
 import com.server.youthtalktalk.domain.post.entity.Review;
-import com.server.youthtalktalk.domain.post.dto.PostCreateReqDto;
 import com.server.youthtalktalk.domain.post.dto.PostRepDto;
 import com.server.youthtalktalk.domain.member.repository.MemberRepository;
 import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
 import com.server.youthtalktalk.domain.post.service.PostService;
 import com.server.youthtalktalk.domain.post.repostiory.PostRepository;
 import com.server.youthtalktalk.domain.scrap.repository.ScrapRepository;
+import com.server.youthtalktalk.global.response.BaseResponseCode;
+import com.server.youthtalktalk.global.response.exception.BusinessException;
+import com.server.youthtalktalk.global.response.exception.InvalidValueException;
+import com.server.youthtalktalk.global.response.exception.policy.PolicyNotFoundException;
+import com.server.youthtalktalk.global.response.exception.post.PostNotFoundException;
+import com.server.youthtalktalk.global.response.exception.report.ReportAlreadyExistException;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -24,6 +36,9 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -39,109 +54,295 @@ class PostServiceTest {
     @Autowired
     private PolicyRepository policyRepository;
     @Autowired
-    private EntityManager em;
+    private PostRepository postRepository;
+    @Autowired
+    private ScrapRepository scrapRepository;
+    @Autowired
+    private ImageRepository imageRepository;
 
     private Member member;
     private Policy policy;
     private Post post;
-    @Autowired
-    private PostRepository postRepository;
-    @Autowired
-    private ScrapRepository scrapRepository;
-
-    private void clear(){
-        em.flush();
-        em.clear();
-    }
-
+    private static final String CONTENT = "content";
+    private static final String IMAGE_URL = "https://example-bucket-name.s3.amazonaws.com/long-file-name-1234";
+    
     @BeforeEach
     void init(){
         this.member = memberRepository.save(Member.builder()
-                .username("testPost")
+                .username("member1")
                 .role(Role.USER)
                 .build());
+
         this.policy = policyRepository.save(Policy.builder()
-                        .policyId("testId")
-                        .title("testPolicy")
+                        .policyId("policyId")
+                        .title("policy1")
                         .category(Category.JOB)
                         .build());
+
         this.post = postRepository.save(Post.builder()
-                .title("test")
+                .title("post1")
                 .writer(member)
+                .contents(getContents(CONTENT, IMAGE_URL))
                 .build());
-        clear();
+
+        imageRepository.save(PostImage.builder().post(null).imgUrl(IMAGE_URL).build());
     }
 
     @Test
-    @DisplayName("상속 관계 매핑 테스트")
-    void inheritanceTest() throws Exception {
-        Policy policy = Policy.builder()
-                .title("test")
-                .category(Category.JOB)
-                .build();
-
-        Review review = Review.builder()
-                .title("test")
-                .content("test")
-                .view(0L)
-                .build();
-        review.setPolicy(policy);
-        Post post = review;
-        Post savedPost = postRepository.save(post);
-        Post free = Post.builder()
-                .title("post")
-                .build();
-
-        assertThat(((Review)savedPost).getPolicy().getTitle()).isEqualTo("test");
-        System.out.println("instance : "+(savedPost instanceof Review));
-    }
-
-    @Test
-    @DisplayName("자유글 생성 성공 테스트")
-    void createPostTest() throws IOException {
+    @DisplayName("자유글 생성 성공")
+    void successCreateFreePost() throws IOException {
+        // Given
         PostCreateReqDto postCreateReqDto = PostCreateReqDto.builder()
                 .policyId(null)
                 .postType("post")
-                .content("test")
-                .title("test")
+                .title("post")
+                .contentList(getContents(CONTENT, IMAGE_URL))
                 .build();
-        PostRepDto result = postService.createPost(postCreateReqDto,null,this.member);
-        assertThat(result.getPostType()).isEqualTo("post");
-        assertThat(result.getContent()).isEqualTo("test");
+        // When
+        PostRepDto postRepDto = postService.createPost(postCreateReqDto,this.member);
+
+        // Then
+        assertThat(postRepDto.getPostType()).isEqualTo("post");
+        assertThat(postRepDto.getTitle()).isEqualTo("post");
+        assertThat(postRepDto.getContentList().get(0).getType()).isEqualTo(ContentType.TEXT);
+        assertThat(postRepDto.getContentList().get(1).getType()).isEqualTo(ContentType.IMAGE);
+        assertThat(postRepDto.getImages().size()).isEqualTo(1);
     }
 
     @Test
-    @DisplayName("리뷰 생성 성공 테스트")
-    void createReviewTest() throws IOException {
+    @DisplayName("리뷰 생성 성공")
+    void successCreateReview() throws IOException {
+        // Given
         PostCreateReqDto postCreateReqDto = PostCreateReqDto.builder()
                 .policyId(this.policy.getPolicyId())
                 .postType("review")
-                .content("test")
-                .title("test")
+                .policyId(policy.getPolicyId())
+                .title("review")
+                .contentList(getContents(CONTENT, IMAGE_URL))
                 .build();
-        PostRepDto result = postService.createPost(postCreateReqDto,null,this.member);
-        assertThat(result.getPostType()).isEqualTo("review");
-        assertThat(result.getContent()).isEqualTo("test");
+        // When
+        PostRepDto postRepDto = postService.createPost(postCreateReqDto,this.member);
+        // Then
+        assertThat(postRepDto.getPostType()).isEqualTo("review");
+        assertThat(postRepDto.getTitle()).isEqualTo("review");
+        assertThat(postRepDto.getContentList().get(0).getType()).isEqualTo(ContentType.TEXT);
+        assertThat(postRepDto.getContentList().get(1).getType()).isEqualTo(ContentType.IMAGE);
+        assertThat(postRepDto.getImages().size()).isEqualTo(1);
     }
 
-//    @Test
-//    @DisplayName("리뷰 수정 성공 테스트")
-//    void updateReviewTest() throws IOException {
-//        PostUpdateReqDto postUpdateReqDto = PostUpdateReqDto.builder()
-//                .title("update")
-//                .content("test")
-//                .build();
-//        PostRepDto postRepDto = postService.updatePost(752L,postUpdateReqDto,null,this.member);
-//        assertThat(postRepDto.getTitle()).isEqualTo("update");
-//    }
+    @Test
+    @DisplayName("존재하지 않는 정책일 경우 리뷰 생성 실패")
+    void failCreateReviewIfNotExistPolicy(){
+        // Given
+        PostCreateReqDto postCreateReqDto = PostCreateReqDto.builder()
+                .policyId(this.policy.getPolicyId())
+                .postType("review")
+                .policyId("notExistId")
+                .title("review")
+                .contentList(getContents(CONTENT, IMAGE_URL))
+                .build();
+        // When
+        // Then
+        assertThatThrownBy(() -> postService.createPost(postCreateReqDto,this.member))
+                .isInstanceOf(PolicyNotFoundException.class);
+    }
 
     @Test
-    @DisplayName("게시글 스크랩 테스트")
-    void scrapPostTest(){
+    @DisplayName("타입이 자유글 혹은 리뷰가 아닌 경우 리뷰 생성 실패")
+    void failCreatePostIfNotExistType(){
+        // Given
+        PostCreateReqDto postCreateReqDto = PostCreateReqDto.builder()
+                .policyId(null)
+                .postType("none")
+                .title("post")
+                .contentList(getContents(CONTENT, IMAGE_URL))
+                .build();
+        // When
+        // Then
+        assertThatThrownBy(() -> postService.createPost(postCreateReqDto,this.member))
+                .isInstanceOf(InvalidValueException.class);
+    }
+
+    @Test
+    @DisplayName("자유글 수정 성공")
+    void successUpdateFreePost() throws IOException {
+        // Given
+        String updatedImageUrl = "https://s3.region-name.amazonaws.com/bucket-name/updatedImage";
+        imageRepository.save(PostImage.builder().post(null).imgUrl(updatedImageUrl).build());
+
+        PostUpdateReqDto postUpdateReqDto = PostUpdateReqDto.builder()
+                .title("updatedTitle")
+                .contentList(getContents("updatedContent", updatedImageUrl))
+                .addImgUrlList(new ArrayList<>(List.of(updatedImageUrl)))
+                .deletedImgUrlList(new ArrayList<>(List.of(IMAGE_URL)))
+                .build();
+        // When
+        PostRepDto postRepDto = postService.updatePost(post.getId(), postUpdateReqDto,this.member);
+        // Then
+        assertThat(postRepDto.getTitle()).isEqualTo("updatedTitle");
+        assertThat(postRepDto.getContentList().get(0).getContent()).isEqualTo("updatedContent");
+        assertThat(postRepDto.getImages().size()).isEqualTo(1);
+        assertThat(postRepDto.getImages().get(0)).isEqualTo(updatedImageUrl);
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 성공")
+    void successUpdateReview() throws IOException {
+        // Given
+        String updatedImageUrl = "https://s3.region-name.amazonaws.com/bucket-name/updatedImage";
+        imageRepository.save(PostImage.builder().post(null).imgUrl(updatedImageUrl).build());
+
+        Review review = postRepository.save(Review.builder()
+                .title("review1")
+                .writer(member)
+                .policy(policy)
+                .contents(getContents(CONTENT, IMAGE_URL))
+                .build());
+
+        PostUpdateReqDto postUpdateReqDto = PostUpdateReqDto.builder()
+                .title("updatedTitle")
+                .contentList(getContents("updatedContent", updatedImageUrl))
+                .policyId(this.policy.getPolicyId())
+                .addImgUrlList(new ArrayList<>(List.of(updatedImageUrl)))
+                .deletedImgUrlList(new ArrayList<>(List.of(IMAGE_URL)))
+                .build();
+        // When
+        PostRepDto postRepDto = postService.updatePost(review.getId(), postUpdateReqDto,this.member);
+        // Then
+        assertThat(postRepDto.getTitle()).isEqualTo("updatedTitle");
+        assertThat(postRepDto.getContentList().get(0).getContent()).isEqualTo("updatedContent");
+        assertThat(postRepDto.getPolicyId()).isEqualTo(review.getPolicy().getPolicyId());
+        assertThat(postRepDto.getImages().size()).isEqualTo(1);
+        assertThat(postRepDto.getImages().get(0)).isEqualTo(updatedImageUrl);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게시글 수정 실패")
+    void failUpdatePostIfNotExistPost() {
+        // Given
+        PostUpdateReqDto postUpdateReqDto = PostUpdateReqDto.builder()
+                .title("updatedTitle")
+                .build();
+        // When, Then
+        assertThatThrownBy(()-> postService.updatePost(Long.MAX_VALUE, postUpdateReqDto, this.member))
+                .isInstanceOf(PostNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("작성자가 아닐 경우 게시글 수정 실패")
+    void failUpdatePostIfNotWriter() {
+        // Given
+        Member other = Member.builder()
+                .username("other")
+                .role(Role.USER)
+                .build();
+        PostUpdateReqDto postUpdateReqDto = PostUpdateReqDto.builder()
+                .title("updatedTitle")
+                .build();
+        // When, Then
+        assertThatThrownBy(()-> postService.updatePost(this.post.getId(), postUpdateReqDto, other))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(BaseResponseCode.POST_ACCESS_DENIED.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 정책일 경우 리뷰 수정 실패")
+    void failUpdatePostIfNotExistPolicy() {
+        // Given
+        Review review = postRepository.save(Review.builder()
+                .title("review1")
+                .writer(member)
+                .contents(getContents(CONTENT, IMAGE_URL))
+                .build());
+        PostUpdateReqDto postUpdateReqDto = PostUpdateReqDto.builder()
+                .title("updatedTitle")
+                .policyId("notExistId")
+                .build();
+        // When, Then
+        assertThatThrownBy(()-> postService.updatePost(review.getId(), postUpdateReqDto, this.member))
+                .isInstanceOf(PolicyNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("게시글 삭제 성공")
+    void successDeletePost(){
+        // When
+        postService.deletePost(this.post.getId(), this.member);
+        // Then
+        assertThat(postRepository.findById(this.post.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게시글 삭제 실패")
+    void failDeletePostIfNotExistPost(){
+        assertThatThrownBy(() -> postService.deletePost(Long.MAX_VALUE, this.member))
+                .isInstanceOf(PostNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("작성자가 아닐 경우 게시글 삭제 실패")
+    void failDeletePostIfNotWriter(){
+        // Given
+        Member other = Member.builder()
+                .username("other")
+                .role(Role.USER)
+                .build();
+        // When, Then
+        assertThatThrownBy(() -> postService.deletePost(this.post.getId(), other))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(BaseResponseCode.POST_ACCESS_DENIED.getMessage());
+    }
+
+    @Test
+    @DisplayName("게시글 스크랩 등록 / 취소 성공")
+    void successScrapPostAndCancel(){
         postService.scrapPost(post.getId(), member); // 스크랩
         assertThat(scrapRepository.existsByMemberIdAndItemIdAndItemType(member.getId(), post.getId().toString(), ItemType.POST)).isTrue();
 
         postService.scrapPost(post.getId(), member); // 스크랩 취소
         assertThat(scrapRepository.existsByMemberIdAndItemIdAndItemType(member.getId(), post.getId().toString(), ItemType.POST)).isFalse();
     }
+
+    @Test
+    @DisplayName("존재하지 않는 게시글 스크랩 실패")
+    void failScrapPostIfNotExistPost(){
+        assertThatThrownBy(() -> postService.scrapPost(Long.MAX_VALUE, this.member))
+                .isInstanceOf(PostNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("게시글 Content 리스트에서 이미지 추출 성공")
+    void successExtractImageUrl(){
+        // Given
+        List<Content> contentList = new ArrayList<>();
+        contentList.add(Content.builder()
+                .content(CONTENT)
+                .type(ContentType.TEXT)
+                .build());
+        for(int i = 0; i < 5; i++){
+            contentList.add(Content.builder()
+                    .content(IMAGE_URL)
+                    .type(ContentType.IMAGE)
+                    .build());
+        }
+        Post post = postRepository.save(Post.builder()
+                .title("post")
+                .writer(member)
+                .contents(contentList)
+                .build());
+
+        // When
+        List<String> imageUrlList = postService.extractImageUrl(post);
+        // Then
+        assertThat(imageUrlList).hasSize(5);
+    }
+
+    List<Content> getContents(String content, String imageUrl){
+        List<Content> contentList = List.of(
+                Content.builder().content(content).type(ContentType.TEXT).build(),
+                Content.builder().content(imageUrl).type(ContentType.IMAGE).build()
+        );
+        return contentList;
+    }
+
 }

--- a/src/test/java/com/server/youthtalktalk/service/post/PostServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/post/PostServiceTest.java
@@ -170,14 +170,19 @@ class PostServiceTest {
         String updatedImageUrl = "https://s3.region-name.amazonaws.com/bucket-name/updatedImage";
         imageRepository.save(PostImage.builder().post(null).imgUrl(updatedImageUrl).build());
 
+        List<String> addImgUrlList = new ArrayList<>();
+        addImgUrlList.add(updatedImageUrl);
+        List<String> deleteImgUrlList = new ArrayList<>();
+        deleteImgUrlList.add(IMAGE_URL);
+
         PostUpdateReqDto postUpdateReqDto = PostUpdateReqDto.builder()
                 .title("updatedTitle")
                 .contentList(getContents("updatedContent", updatedImageUrl))
-                .addImgUrlList(new ArrayList<>(List.of(updatedImageUrl)))
-                .deletedImgUrlList(new ArrayList<>(List.of(IMAGE_URL)))
+                .addImgUrlList(addImgUrlList)
+                .deletedImgUrlList(deleteImgUrlList)
                 .build();
         // When
-        PostRepDto postRepDto = postService.updatePost(post.getId(), postUpdateReqDto,this.member);
+        PostRepDto postRepDto = postService.updatePost(post.getId(), postUpdateReqDto, this.member);
         // Then
         assertThat(postRepDto.getTitle()).isEqualTo("updatedTitle");
         assertThat(postRepDto.getContentList().get(0).getContent()).isEqualTo("updatedContent");
@@ -199,12 +204,17 @@ class PostServiceTest {
                 .contents(getContents(CONTENT, IMAGE_URL))
                 .build());
 
+        List<String> addImgUrlList = new ArrayList<>();
+        addImgUrlList.add(updatedImageUrl);
+        List<String> deleteImgUrlList = new ArrayList<>();
+        deleteImgUrlList.add(IMAGE_URL);
+
         PostUpdateReqDto postUpdateReqDto = PostUpdateReqDto.builder()
                 .title("updatedTitle")
                 .contentList(getContents("updatedContent", updatedImageUrl))
                 .policyId(this.policy.getPolicyId())
-                .addImgUrlList(new ArrayList<>(List.of(updatedImageUrl)))
-                .deletedImgUrlList(new ArrayList<>(List.of(IMAGE_URL)))
+                .addImgUrlList(addImgUrlList)
+                .deletedImgUrlList(deleteImgUrlList)
                 .build();
         // When
         PostRepDto postRepDto = postService.updatePost(review.getId(), postUpdateReqDto,this.member);
@@ -338,10 +348,10 @@ class PostServiceTest {
     }
 
     List<Content> getContents(String content, String imageUrl){
-        List<Content> contentList = List.of(
+        List<Content> contentList = new ArrayList<>(List.of(
                 Content.builder().content(content).type(ContentType.TEXT).build(),
                 Content.builder().content(imageUrl).type(ContentType.IMAGE).build()
-        );
+        ));
         return contentList;
     }
 


### PR DESCRIPTION
1. 테스트 구현
- PostService
- PostReadService
- PostRepositoryCustom(미완)
- ReportService

2. 컬럼 타입 변경
- 글자수 제한 해제를 위해 content를 TEXT 타입으로 변경

3. 인기 게시글 조회 쿼리 수정
- 기존 : page size를 5로 설정하여 페이징으로 조회 후 게시글 페이지 반환, 전체 요소 수가 필요해서 조회 쿼리 한번 더 호출해야함 (비효율적)
- 변경 후 : limit() 메서드를 이용하여 상위 5개만 List로 반환 