### PR TITLE
[FIX] 온통청년 api data fetch 에러 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.mockito:mockito-core:4.8.0'
+	testImplementation 'org.mockito:mockito-inline:3.12.4'
 	testRuntimeOnly 'com.h2database:h2'
 
 	// JUnit 5 (JUnit Jupiter) 의존성 명시적 선언

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
@@ -1,8 +1,10 @@
 package com.server.youthtalktalk.domain.policy.dto.data;
 
+
 import com.server.youthtalktalk.domain.policy.entity.*;
 import com.server.youthtalktalk.domain.policy.entity.condition.*;
 import com.server.youthtalktalk.domain.policy.entity.region.Region;
+import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDate;
@@ -10,6 +12,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
 @Slf4j
+@Builder
 public record PolicyData(
         String operInstCdNm,
         String bscPlanAsmtNo,
@@ -72,74 +75,67 @@ public record PolicyData(
     private static final String regionCode = "0054002";
 
     public Policy toPolicy() {
-        try {
-            RepeatCode repeatCode = RepeatCode.fromKey(plcyNo, aplyPrdSeCd);
+        RepeatCode repeatCode = RepeatCode.fromKey(plcyNo, aplyPrdSeCd);
 
-            // 신청 기간 파싱(상시인 경우 x)
-            if (aplyYmd.length() > 20) {
-                log.info("aplyYmd policyId = {}", plcyNo);
-            }
-
-            String[] dates = aplyYmd.split("\\\\N");
-            if (dates.length > 1 && !isEqualApplyDates(dates)) { // 서로 다른 신청 기간이 여러 개인 경우
-                repeatCode = RepeatCode.ALWAYS; // 상시 처리
-            }
-
-            LocalDate[] applyDates = parsingApplyYmd(dates[0]);
-            LocalDate applyStart = applyDates[0];
-            LocalDate applyDue = applyDates[1];
-
-            Earn earn = Earn.fromKey(plcyNo, earnCndSeCd);
-            boolean isLimitedAge = sprtTrgtAgeLmtYn.equals("N");
-            Region region = findRegion();
-            InstitutionType institutionType = findType(pvsnInstGroupCd);
-            LocalDate[] bizTerm = parsingBizTerm();
-
-            return Policy.builder()
-                    .policyId(plcyNo)
-                    .region(region)
-                    .title(plcyNm)
-                    .institutionType(institutionType)
-                    .isLimitedAge(isLimitedAge)
-                    .minAge(isLimitedAge && !sprtTrgtMinAge.isEmpty() ? Integer.parseInt(sprtTrgtMinAge) : 0)
-                    .maxAge(isLimitedAge && !sprtTrgtMaxAge.isEmpty() ? Integer.parseInt(sprtTrgtMaxAge) : 0)
-                    .repeatCode(repeatCode)
-                    .applyTerm(aplyYmd)
-                    .applyStart(applyStart)
-                    .applyDue(applyDue)
-                    .addition(addAplyQlfcCndCn)
-                    .etc(etcMttrCn)
-                    .applLimit(ptcpPrpTrgtCn)
-                    .applStep(plcyAplyMthdCn)
-                    .applUrl(aplyUrlAddr)
-                    .category(Category.fromKey(plcyNo, bscPlanPlcyWayNo))
-                    .education(Education.findEducationList(plcyNo, schoolCd))
-                    .employment(Employment.findEmploymentList(plcyNo, jobCd))
-                    .hostDep(sprvsnInstCdNm)
-                    .refUrl1(refUrlAddr1)
-                    .refUrl2(refUrlAddr2)
-                    .evaluation(srngMthdCn)
-                    .introduction(plcyExplnCn)
-                    .operatingOrg(operInstCdNm)
-                    .specialization(Specialization.findSpecializationList(plcyNo, sbizCd))
-                    .major(Major.findMajorList(plcyNo, plcyMajorCd))
-                    .submitDoc(sbmsnDcmntCn)
-                    .supportDetail(plcySprtCn)
-                    .subCategory(SubCategory.fromKey(plcyNo, bscPlanFcsAsmtNo))
-                    .earn(earn)
-                    .maxEarn(earn.equals(Earn.ANNUL_INCOME) && !earnMaxAmt.isEmpty() ? Integer.parseInt(earnMaxAmt) : 0)
-                    .minEarn(earn.equals(Earn.ANNUL_INCOME) && !earnMinAmt.isEmpty() ? Integer.parseInt(earnMinAmt) : 0)
-                    .earnEtc(earnEtcCn)
-                    .marriage(Marriage.fromKey(plcyNo, mrgSttsCd))
-                    .zipCd(zipCd)
-                    .bizStart(bizTerm[0])
-                    .bizDue(bizTerm[1])
-                    .build();
-
-        } catch (Exception e) {
-            log.info("policyId = {}", plcyNo, e);
-            throw new RuntimeException(e);
+        // 신청 기간 파싱(상시인 경우 x)
+        if (aplyYmd.length() > 20) {
+            log.info("aplyYmd policyId = {}", plcyNo);
         }
+
+        String[] dates = aplyYmd.split("\\\\N");
+        if (dates.length > 1 && !isEqualApplyDates(dates)) { // 서로 다른 신청 기간이 여러 개인 경우
+            repeatCode = RepeatCode.ALWAYS; // 상시 처리
+        }
+
+        LocalDate[] applyDates = parsingApplyYmd(dates[0]);
+        LocalDate applyStart = applyDates[0];
+        LocalDate applyDue = applyDates[1];
+
+        Earn earn = Earn.fromKey(plcyNo, earnCndSeCd);
+        boolean isLimitedAge = sprtTrgtAgeLmtYn.equals("N");
+        Region region = findRegion();
+        LocalDate[] bizTerm = parsingBizTerm();
+
+        return Policy.builder()
+                .policyId(plcyNo)
+                .region(region)
+                .title(plcyNm)
+                .institutionType(InstitutionType.fromKey(plcyNo, pvsnInstGroupCd))
+                .isLimitedAge(isLimitedAge)
+                .minAge(isLimitedAge && !sprtTrgtMinAge.isEmpty() ? Integer.parseInt(sprtTrgtMinAge) : 0)
+                .maxAge(isLimitedAge && !sprtTrgtMaxAge.isEmpty() ? Integer.parseInt(sprtTrgtMaxAge) : 0)
+                .repeatCode(repeatCode)
+                .applyTerm(aplyYmd)
+                .applyStart(applyStart)
+                .applyDue(applyDue)
+                .addition(addAplyQlfcCndCn)
+                .etc(etcMttrCn)
+                .applLimit(ptcpPrpTrgtCn)
+                .applStep(plcyAplyMthdCn)
+                .applUrl(aplyUrlAddr)
+                .category(Category.fromKey(plcyNo, bscPlanPlcyWayNo))
+                .education(Education.findEducationList(plcyNo, schoolCd))
+                .employment(Employment.findEmploymentList(plcyNo, jobCd))
+                .hostDep(sprvsnInstCdNm)
+                .refUrl1(refUrlAddr1)
+                .refUrl2(refUrlAddr2)
+                .evaluation(srngMthdCn)
+                .introduction(plcyExplnCn)
+                .operatingOrg(operInstCdNm)
+                .specialization(Specialization.findSpecializationList(plcyNo, sbizCd))
+                .major(Major.findMajorList(plcyNo, plcyMajorCd))
+                .submitDoc(sbmsnDcmntCn)
+                .supportDetail(plcySprtCn)
+                .subCategory(SubCategory.fromKey(plcyNo, bscPlanFcsAsmtNo))
+                .earn(earn)
+                .maxEarn(earn.equals(Earn.ANNUL_INCOME) && !earnMaxAmt.isEmpty() ? Integer.parseInt(earnMaxAmt) : 0)
+                .minEarn(earn.equals(Earn.ANNUL_INCOME) && !earnMinAmt.isEmpty() ? Integer.parseInt(earnMinAmt) : 0)
+                .earnEtc(earnEtcCn)
+                .marriage(Marriage.fromKey(plcyNo, mrgSttsCd))
+                .zipCd(zipCd)
+                .bizStart(bizTerm[0])
+                .bizDue(bizTerm[1])
+                .build();
     }
 
     // 지역 코드 매핑
@@ -189,14 +185,5 @@ public record PolicyData(
             compare = date;
         }
         return true;
-    }
-
-    // 담당 기관 타입 매핑
-    private InstitutionType findType(String pvsnInstGroupCd){
-        return switch(pvsnInstGroupCd){
-            case "0054001" -> InstitutionType.CENTER;
-            case "0054002" -> InstitutionType.LOCAL;
-            default -> throw new RuntimeException("Invalid InstitutionType");
-        };
     }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/Category.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/Category.java
@@ -1,10 +1,14 @@
 package com.server.youthtalktalk.domain.policy.entity;
 
+import com.server.youthtalktalk.global.response.BaseResponseCode;
+import com.server.youthtalktalk.global.response.exception.policy.FailPolicyDataException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Getter
 @RequiredArgsConstructor
+@Slf4j
 public enum Category {
     JOB("일자리"),
     DWELLING("주거"),
@@ -21,7 +25,10 @@ public enum Category {
             case "003" -> Category.EDUCATION;
             case "004" -> Category.LIFE;
             case "005" -> Category.PARTICIPATION;
-            default -> throw new RuntimeException("Illegal Category :" + policyId);
+            default -> {
+                log.error("[Policy Data] Not Existed Category = {}, policyId = {}", key, policyId);
+                throw new FailPolicyDataException(BaseResponseCode.FAIL_POLICY_DATA_CATEGORY);
+            }
         };
     }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/InstitutionType.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/InstitutionType.java
@@ -1,8 +1,26 @@
 package com.server.youthtalktalk.domain.policy.entity;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Getter
+@RequiredArgsConstructor
+@Slf4j
 public enum InstitutionType {
-    CENTER, LOCAL;
+    CENTER("0054001"),
+    LOCAL("0054002");
+
+    private final String key;
+    // 담당 기관 타입 매핑
+    public static InstitutionType fromKey(String policyId, String key){
+        return switch (key) {
+            case "0054001" -> InstitutionType.CENTER;
+            case "0054002" -> InstitutionType.LOCAL;
+            default -> {
+                log.error("[Policy Data] Not Existed InstitutionType = {}, policyId = {}", key, policyId);
+                yield InstitutionType.CENTER;
+            }
+        };
+    }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/Policy.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/Policy.java
@@ -51,20 +51,6 @@ public class Policy extends BaseTimeEntity {
 
     private int maxAge; // 최대 연령
 
-    //@Column(columnDefinition = "TEXT")
-    //private String employment; // 취업 상태
-
-    //private String employmentCode; // 취업 상태 코드 리스트
-
-    //private String specialization; // 특화 분야
-
-    //private String major; // 전공 요건
-
-    //private String education; // 학력 요건
-
-    //@Column(columnDefinition = "TEXT")
-    //private String addrIncome; // 거주지 및 소득 조건
-
     @Column(columnDefinition = "TEXT")
     private String addition; // 추가 사항
 

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/RepeatCode.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/RepeatCode.java
@@ -2,9 +2,11 @@ package com.server.youthtalktalk.domain.policy.entity;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Getter
 @RequiredArgsConstructor
+@Slf4j
 public enum RepeatCode {
     ALWAYS("0057002","상시"),
     PERIOD("0057001","특정기간"),
@@ -14,11 +16,14 @@ public enum RepeatCode {
     private final String name;
 
     public static RepeatCode fromKey(String policyId, String key){
-        return switch(key){
+        return switch (key) {
             case "0057001" -> RepeatCode.PERIOD;
             case "0057002" -> RepeatCode.ALWAYS;
             case "0057003" -> RepeatCode.UNDEFINED;
-            default -> throw new RuntimeException("Illegal RepeatCode : " + policyId);
+            default -> {
+                log.error("[Policy Data] Not Existed RepeatCode = {}, policyId = {}", key, policyId);
+                yield RepeatCode.ALWAYS; // 값이 없는 경우 상시 처리
+            }
         };
     }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/SubCategory.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/SubCategory.java
@@ -1,10 +1,14 @@
 package com.server.youthtalktalk.domain.policy.entity;
 
+import com.server.youthtalktalk.global.response.BaseResponseCode;
+import com.server.youthtalktalk.global.response.exception.policy.FailPolicyDataException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Getter
 @RequiredArgsConstructor
+@Slf4j
 public enum SubCategory {
     JOB_EXPANSION("001","일자리 확대 및 역량 강화"),
     JOB_STARTUP("002","창업"),
@@ -36,6 +40,7 @@ public enum SubCategory {
                 return subCategory;
             }
         }
-        throw new RuntimeException("Illegal SubCategory : " + policyId);
+        log.error("[Policy Data] Not Existed SubCategory = {} policyId = {}", key, policyId);
+        throw new FailPolicyDataException(BaseResponseCode.FAIL_POLICY_DATA_SUB_CATEGORY);
     }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Earn.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Earn.java
@@ -18,8 +18,7 @@ public enum Earn {
             case "0043001" -> Earn.UNRESTRICTED;
             case "0043002" -> Earn.ANNUL_INCOME;
             case "0043003" -> Earn.OTHER;
-            //default -> throw new RuntimeException("Illegal Earn : " + policyId);
-            default -> Earn.UNRESTRICTED;
+            default -> Earn.UNRESTRICTED; // 기본값은 제한 없음
         };
     }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Education.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Education.java
@@ -1,12 +1,16 @@
 package com.server.youthtalktalk.domain.policy.entity.condition;
 
+import com.server.youthtalktalk.global.response.BaseResponseCode;
+import com.server.youthtalktalk.global.response.exception.policy.FailPolicyDataException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.*;
 
 @Getter
 @RequiredArgsConstructor
+@Slf4j
 public enum Education {
     HIGHSCHOOL_BELOW("0049001", "고졸 미만"),
     HIGHSCHOOL_STUDENT("0049002", "고교 재학"),
@@ -28,7 +32,8 @@ public enum Education {
                 return education;
             }
         }
-        throw new RuntimeException("Not Existed Education");
+        log.error("[Policy Data] Not Existed Education = {}", key);
+        throw new FailPolicyDataException(BaseResponseCode.FAIL_POLICY_DATA_EDUCATION);
     }
 
     public static List<Education> findEducationList(String policyId, String data){
@@ -44,7 +49,8 @@ public enum Education {
         }
 
         if(set.size() != educationList.size()) {
-            throw new RuntimeException("Not Existed Education : " + policyId);
+            log.error("[Policy Data] Not Existed Education = {} policyId = {}", data, policyId);
+            throw new FailPolicyDataException(BaseResponseCode.FAIL_POLICY_DATA_EDUCATION);
         }
         return educationList;
     }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Employment.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Employment.java
@@ -1,12 +1,16 @@
 package com.server.youthtalktalk.domain.policy.entity.condition;
 
+import com.server.youthtalktalk.global.response.BaseResponseCode;
+import com.server.youthtalktalk.global.response.exception.policy.FailPolicyDataException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.*;
 
 @Getter
 @RequiredArgsConstructor
+@Slf4j
 public enum Employment {
     EMPLOYED("0013001", "재직자"),
     SELF_EMPLOYED("0013002", "자영업자"),
@@ -28,7 +32,8 @@ public enum Employment {
                 return employment;
             }
         }
-        throw new RuntimeException("Not Existed Employment");
+        log.error("[Policy Data] Not Existed Employment = {}", key);
+        throw new FailPolicyDataException(BaseResponseCode.FAIL_POLICY_DATA_EMPLOYMENT);
     }
 
     public static List<Employment> findEmploymentList(String policyId, String data){
@@ -44,7 +49,8 @@ public enum Employment {
         }
 
         if(set.size() != employmentList.size()) {
-            throw new RuntimeException("Not Existed Employment : " + policyId);
+            log.error("[Policy Data] Not Existed Employment = {} policyId = {}", data, policyId);
+            throw new FailPolicyDataException(BaseResponseCode.FAIL_POLICY_DATA_EMPLOYMENT);
         }
         return employmentList;
     }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Major.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Major.java
@@ -1,12 +1,16 @@
 package com.server.youthtalktalk.domain.policy.entity.condition;
 
+import com.server.youthtalktalk.global.response.BaseResponseCode;
+import com.server.youthtalktalk.global.response.exception.policy.FailPolicyDataException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.*;
 
 @Getter
 @RequiredArgsConstructor
+@Slf4j
 public enum Major {
     HUMANITIES("0011001", "인문계열"),
     SOCIETY("0011002", "사회계열"),
@@ -27,7 +31,8 @@ public enum Major {
                 return major;
             }
         }
-        throw new RuntimeException("Not Existed Major");
+        log.error("[Policy Data] Not Existed Major = {}", key);
+        throw new FailPolicyDataException(BaseResponseCode.FAIL_POLICY_DATA_MAJOR);
     }
 
     public static List<Major> findMajorList(String policyId, String data){
@@ -43,7 +48,8 @@ public enum Major {
         }
 
         if(set.size() != majorList.size()) {
-            throw new RuntimeException("Not Existed Major : " + policyId);
+            log.error("[Policy Data] Not Existed Major = {} policyId = {}", data, policyId);
+            throw new FailPolicyDataException(BaseResponseCode.FAIL_POLICY_DATA_MAJOR);
         }
         return majorList;
     }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Marriage.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Marriage.java
@@ -18,8 +18,7 @@ public enum Marriage {
                 case "0055001" -> Marriage.MARRIED;
                 case "0055002" -> Marriage.SINGLE;
                 case "0055003" -> Marriage.UNRESTRICTED;
-                //default -> throw new RuntimeException("Illegal Marriage : " + policyId);
-                default -> Marriage.UNRESTRICTED;
+                default -> Marriage.UNRESTRICTED; // 기본값
         };
     }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Specialization.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Specialization.java
@@ -1,12 +1,16 @@
 package com.server.youthtalktalk.domain.policy.entity.condition;
 
+import com.server.youthtalktalk.global.response.BaseResponseCode;
+import com.server.youthtalktalk.global.response.exception.policy.FailPolicyDataException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.*;
 
 @Getter
 @RequiredArgsConstructor
+@Slf4j
 public enum Specialization {
     SMALL_BUSINESS("0014001", "중소기업"),
     WOMEN("0014002", "여성"),
@@ -28,7 +32,8 @@ public enum Specialization {
                 return specialization;
             }
         }
-        throw new RuntimeException("Not Existed Specialization");
+        log.error("[Policy Data] Not Existed Specialization = {}, policyId = {}", key, policyId);
+        throw new FailPolicyDataException(BaseResponseCode.FAIL_POLICY_DATA_SPECIALIZATION);
     }
 
     public static List<Specialization> findSpecializationList(String policyId, String data){
@@ -44,7 +49,8 @@ public enum Specialization {
         }
 
         if(set.size() != specializationList.size()) {
-            throw new RuntimeException("Not Existed Specialization : " + policyId);
+            log.error("[Policy Data] Not Existed Specialization = {}, policyId = {}", data, policyId);
+            throw new FailPolicyDataException(BaseResponseCode.FAIL_POLICY_DATA_SPECIALIZATION);
         }
         return specializationList;
     }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/region/Region.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/region/Region.java
@@ -8,27 +8,28 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Region {
-    SEOUL("6110000","서울"),
-    BUSAN("6260000","부산"),
-    DAEGU("6270000","대구"),
-    INCHEON("6280000","인천"),
-    GWANGJU("6290000","광주"),
-    DAEJEON("6300000","대전"),
-    ULSAN("6310000","울산"),
-    GYEONGGI("6410000","경기"),
-    GANGWON("6420000","강원"),
-    CHUNGBUK("6430000","충북"),
-    CHUNGNAM("6440000","충남"),
-    JEONBUK("6540000","전북"),
-    JEONNAM("6460000","전남"),
-    GYEONGBUK("6470000","경북"),
-    GYEONGNAM("6480000","경남"),
-    JEJU("6500000","제주"),
-    SEJONG("5690000","세종"),
-    ALL("중앙부처","전국");
+    SEOUL("6110000","서울", 11),
+    BUSAN("6260000","부산", 26),
+    DAEGU("6270000","대구", 27),
+    INCHEON("6280000","인천", 28),
+    GWANGJU("6290000","광주", 29),
+    DAEJEON("6300000","대전", 30),
+    ULSAN("6310000","울산", 31),
+    GYEONGGI("6410000","경기", 41),
+    GANGWON("6530000","강원", 51),
+    CHUNGBUK("6430000","충북", 43),
+    CHUNGNAM("6440000","충남", 44),
+    JEONBUK("6540000","전북", 52),
+    JEONNAM("6460000","전남", 46),
+    GYEONGBUK("6470000","경북", 47),
+    GYEONGNAM("6480000","경남", 48),
+    JEJU("6500000","제주", 50),
+    SEJONG("5690000","세종", 36),
+    ALL("중앙부처","전국", -1);
 
     private final String key;
     private final String name;
+    private final int num;
 
     public static Region fromRegionStr(String regionStr) {
         for (Region region : Region.values()) {
@@ -46,5 +47,14 @@ public enum Region {
             }
         }
         return null; // 맞는 Region이 없는 경우
+    }
+
+    public static Region fromNum(int num) {
+        for (Region region : Region.values()) {
+            if(region.getNum() == num){
+                return region;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/data/PolicyDataService.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/data/PolicyDataService.java
@@ -2,10 +2,15 @@ package com.server.youthtalktalk.domain.policy.service.data;
 
 import com.server.youthtalktalk.domain.policy.dto.data.PolicyData;
 import com.server.youthtalktalk.domain.policy.entity.Policy;
+import com.server.youthtalktalk.domain.policy.entity.region.PolicySubRegion;
+import com.server.youthtalktalk.domain.policy.entity.region.Region;
 
 import java.util.List;
 
 public interface PolicyDataService {
     void saveData();
     List<PolicyData> fetchData();
+    List<PolicySubRegion> setPolicySubRegions(Policy policy);
+    Region searchRegionByZipCd(Policy policy);
+    List<Policy> getPolicyEntityList(List<PolicyData> policyDataList);
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/data/PolicyDataServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/data/PolicyDataServiceImpl.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
@@ -34,13 +35,14 @@ public class PolicyDataServiceImpl implements PolicyDataService {
 
     @Value("${youthpolicy.api.secret-key}")
     private String secretKey;
-    private int pageSize = 100;
-    private static final String regionCode = "0054002";
+    private static final int PAGE_SIZE = 27;
+    private static final int LIMIT = 500;
 
     @Override
     @Transactional
     @Scheduled(cron = "${youthpolicy.cron}")
     public void saveData() {
+        log.info("[온통청년 Data Fetch] Data fetch start");
         List<PolicyData> policyDataList = fetchData();
         List<Policy> policyList = policyDataList.stream()
                 .map(policyData -> {
@@ -51,9 +53,11 @@ public class PolicyDataServiceImpl implements PolicyDataService {
                     return policy;
                 })
                 .toList();
-        List<Policy> savedPolicyList = policyRepository.saveAll(policyList);
 
-        policySubRegionRepository.deleteAllByPolicyIn(policyList);
+        log.info("[온통청년 Data Fetch] Fetched policies save to DB");
+        List<Policy> savedPolicyList = policyRepository.saveAll(policyList);
+        log.info("[온통청년 Data Fetch] Mapping with sub regions");
+        policySubRegionRepository.deleteAllByPolicyIn(savedPolicyList);
         // 하위 지역 코드 매핑
         List<PolicySubRegion> policySubRegionList = new ArrayList<>();
         savedPolicyList.stream()
@@ -67,38 +71,50 @@ public class PolicyDataServiceImpl implements PolicyDataService {
         List<PolicyData> dataList = new ArrayList<>();
         WebClient webClient = WebClient.builder()
                 .baseUrl("https://www.youthcenter.go.kr/")
-                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(16 * 1024 * 1024))  // 예: 16MB
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(16 * 1024 * 1024)) // 16MB 설정
+                .filter(logRequest())
                 .build();
 
-        int pageIndex = 1; // 페이지 인덱스는 1부터 시작
+        int pageIndex = 1;
         boolean hasMoreData = true;
-        while(hasMoreData){
-            // api 호출 response 받기
+        while (pageIndex < LIMIT) {
             int pageNum = pageIndex;
-            Mono<PolicyDataList> response = webClient.get()
-                    .uri(uriBuilder -> uriBuilder
-                            .path("/go/ythip/getPlcy")
-                            .queryParam("apiKeyNm", secretKey)
-                            .queryParam("pageSize", pageSize)
-                            .queryParam("pageNum", pageNum)
-                            .queryParam("rtnType", "json")
-                            .queryParam("pageType", "1") // 목록 출력
-                            .build())
-                    .retrieve()
-                    .bodyToMono(PolicyDataList.class)
-                    .retryWhen(Retry.backoff(5, Duration.ofSeconds(2))
-                            .filter(throwable -> throwable instanceof WebClientResponseException
-                                    && ((WebClientResponseException) throwable).getStatusCode().is5xxServerError()))
-                    .onErrorResume(e -> Mono.error(new FailPolicyDataFetchException()));
+            PolicyDataList policyDataList = null;
+            try {
+                Mono<PolicyDataList> response = webClient.get()
+                        .uri(uriBuilder -> uriBuilder
+                                .path("/go/ythip/getPlcy")
+                                .queryParam("apiKeyNm", secretKey)
+                                .queryParam("pageSize", PAGE_SIZE)
+                                .queryParam("pageNum", pageNum)
+                                .queryParam("rtnType", "json")
+                                .queryParam("pageType", "1")
+                                .build())
+                        .retrieve()
+                        .bodyToMono(PolicyDataList.class)
+                        .retryWhen(Retry.backoff(5, Duration.ofSeconds(2))
+                                .doBeforeRetry(before -> log.info("[온통청년 Data Fetch] Retry : {}", before.toString()))
+                                .filter(throwable -> throwable instanceof WebClientResponseException
+                                        && ((WebClientResponseException) throwable).getStatusCode().is5xxServerError()))
+                        .onErrorResume(e -> {
+                            log.error("[온통청년 Data Fetch] API 호출 실패: {}", e.getMessage());
+                            throw new FailPolicyDataFetchException();
+                        });
+                policyDataList = response.block();
+            } catch (Exception e) {
+                throw new FailPolicyDataFetchException();
+            }
 
-            // 정책 리스트 추출
-            List<PolicyData> youthPolicies = Optional
-                    .ofNullable(response.block().result().youthPolicyList())
+            if(policyDataList == null || policyDataList.result() == null){
+                throw new RuntimeException("[온통청년 Data Fetch] data fetch null error");
+            }
+
+            List<PolicyData> youthPolicies = Optional.ofNullable(policyDataList.result().youthPolicyList())
                     .orElse(Collections.emptyList());
 
             if (youthPolicies.isEmpty()) {
-                log.info("No more policies available");
-                hasMoreData=false;
+                log.info("[온통청년 Data Fetch] No more data found, loop break");
+                break;
             }
             dataList.addAll(youthPolicies);
             pageIndex++;
@@ -144,4 +160,16 @@ public class PolicyDataServiceImpl implements PolicyDataService {
         }
     }
 
+    private ExchangeFilterFunction logRequest() {
+        return ExchangeFilterFunction.ofRequestProcessor(clientRequest -> {
+            log.info("Request URL: {}", clientRequest.url()); // 요청 URL + 파라미터 출력
+            return Mono.just(clientRequest);
+        });
+    }
+
 }
+
+
+
+
+

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/data/PolicyDataServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/data/PolicyDataServiceImpl.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 
@@ -35,8 +36,8 @@ public class PolicyDataServiceImpl implements PolicyDataService {
 
     @Value("${youthpolicy.api.secret-key}")
     private String secretKey;
-    private static final int PAGE_SIZE = 27;
-    private static final int LIMIT = 500;
+    private static final int PAGE_SIZE = 50;
+    private static final int LIMIT = 1000;
 
     @Override
     @Transactional
@@ -44,20 +45,13 @@ public class PolicyDataServiceImpl implements PolicyDataService {
     public void saveData() {
         log.info("[온통청년 Data Fetch] Data fetch start");
         List<PolicyData> policyDataList = fetchData();
-        List<Policy> policyList = policyDataList.stream()
-                .map(policyData -> {
-                    Policy policy = policyData.toPolicy();
-                    if (policy.getRegion() == null) { // 지역이 설정되지 않은 경우
-                        policy = setRegionForPolicy(policy); // 지역 설정 로직을 메서드로 분리
-                    }
-                    return policy;
-                })
-                .toList();
+        List<Policy> policyList = getPolicyEntityList(policyDataList);
 
         log.info("[온통청년 Data Fetch] Fetched policies save to DB");
         List<Policy> savedPolicyList = policyRepository.saveAll(policyList);
         log.info("[온통청년 Data Fetch] Mapping with sub regions");
         policySubRegionRepository.deleteAllByPolicyIn(savedPolicyList);
+
         // 하위 지역 코드 매핑
         List<PolicySubRegion> policySubRegionList = new ArrayList<>();
         savedPolicyList.stream()
@@ -67,16 +61,34 @@ public class PolicyDataServiceImpl implements PolicyDataService {
     }
 
     @Override
+    public List<Policy> getPolicyEntityList(List<PolicyData> policyDataList) {
+        return policyDataList.stream()
+                .map(policyData -> {
+                    try {
+                        Policy policy = policyData.toPolicy(); // policy 생성
+                        if (policy.getRegion() == null) { // 지역이 설정되지 않은 경우
+                            policy = setRegionForPolicy(policy); // 지역 설정 로직을 메서드로 분리
+                        }
+                        return policy; // 정상적으로 생성된 policy 반환
+                    } catch (Exception e) {
+                        // 예외 발생 시 로깅하거나 예외를 처리하고, null을 반환하여 리스트에 추가되지 않도록 함
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull) // null인 항목은 필터링하여 제거
+                .toList();
+    }
+
+    @Override
     public List<PolicyData> fetchData() {
         List<PolicyData> dataList = new ArrayList<>();
         WebClient webClient = WebClient.builder()
                 .baseUrl("https://www.youthcenter.go.kr/")
                 .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(16 * 1024 * 1024)) // 16MB 설정
-                .filter(logRequest())
+                //.filter(logRequest())
                 .build();
 
         int pageIndex = 1;
-        boolean hasMoreData = true;
         while (pageIndex < LIMIT) {
             int pageNum = pageIndex;
             PolicyDataList policyDataList = null;
@@ -94,8 +106,7 @@ public class PolicyDataServiceImpl implements PolicyDataService {
                         .bodyToMono(PolicyDataList.class)
                         .retryWhen(Retry.backoff(5, Duration.ofSeconds(2))
                                 .doBeforeRetry(before -> log.info("[온통청년 Data Fetch] Retry : {}", before.toString()))
-                                .filter(throwable -> throwable instanceof WebClientResponseException
-                                        && ((WebClientResponseException) throwable).getStatusCode().is5xxServerError()))
+                                .filter(throwable -> throwable instanceof WebClientResponseException))
                         .onErrorResume(e -> {
                             log.error("[온통청년 Data Fetch] API 호출 실패: {}", e.getMessage());
                             throw new FailPolicyDataFetchException();
@@ -119,11 +130,12 @@ public class PolicyDataServiceImpl implements PolicyDataService {
             dataList.addAll(youthPolicies);
             pageIndex++;
         }
+
         return dataList;
     }
 
-
-    private List<PolicySubRegion> setPolicySubRegions(Policy policy) {
+    @Override
+    public List<PolicySubRegion> setPolicySubRegions(Policy policy) {
         // zipCd 거주 지역 코드 파싱
         String[] regionCodes = policy.getZipCd().split(",");
         List<String> codeList = Arrays.stream(regionCodes).toList();
@@ -141,23 +153,22 @@ public class PolicyDataServiceImpl implements PolicyDataService {
         return policySubRegionList;
     }
 
-    private Region searchRegionByZipCd(Policy policy){
+    @Override
+    public Region searchRegionByZipCd(Policy policy){
         String[] regionCodes = policy.getZipCd().split(",");
         if(!regionCodes[0].isBlank()){
-            SubRegion subRegion = subRegionRepository.findByCode(regionCodes[0])
-                    .orElseThrow(() -> new RuntimeException("Not Existed Region Code"));
-            return subRegion.getRegion();
+            Region region = Region.fromNum(Integer.valueOf(regionCodes[0].substring(0,2)));
+            if(region == null){
+                return Region.ALL;
+            }
+            return region;
         }
-        return null;
+        return Region.ALL;
     }
 
     private Policy setRegionForPolicy(Policy policy) {
         Region region = searchRegionByZipCd(policy);
-        if (region == null) {
-            return policy.toBuilder().region(Region.ALL).build();
-        } else {
-            return policy.toBuilder().region(region).build();
-        }
+        return policy.toBuilder().region(region).build();
     }
 
     private ExchangeFilterFunction logRequest() {
@@ -166,7 +177,6 @@ public class PolicyDataServiceImpl implements PolicyDataService {
             return Mono.just(clientRequest);
         });
     }
-
 }
 
 

--- a/src/main/java/com/server/youthtalktalk/global/config/WebConfig.java
+++ b/src/main/java/com/server/youthtalktalk/global/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.server.youthtalktalk.global.config;
+
+import com.server.youthtalktalk.global.log.LoggingFilter;
+import jakarta.servlet.Filter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Bean
+    public FilterRegistrationBean loggingFilter() {
+        FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
+        filterRegistrationBean.setFilter(new LoggingFilter());
+        filterRegistrationBean.setOrder(0);
+        filterRegistrationBean.addUrlPatterns("/api/*");
+
+        return filterRegistrationBean;
+    }
+}

--- a/src/main/java/com/server/youthtalktalk/global/response/BaseResponseCode.java
+++ b/src/main/java/com/server/youthtalktalk/global/response/BaseResponseCode.java
@@ -55,6 +55,12 @@ public enum BaseResponseCode {
     // Policy
     POLICY_NOT_FOUND("PC01","해당 정책을 찾을 수 없습니다.",HttpStatus.BAD_REQUEST.value()),
     FAIL_POLICY_DATA_FETCH("PC02", "정책 데이터 패치 실패", HttpStatus.INTERNAL_SERVER_ERROR.value()),
+    FAIL_POLICY_DATA_EDUCATION("PC03", "정책 데이터 엔티티 변환 실패 : 존재하지 않는 교육 요건", HttpStatus.INTERNAL_SERVER_ERROR.value()),
+    FAIL_POLICY_DATA_EMPLOYMENT("PC04", "정책 데이터 엔티티 변환 실패 : 존재하지 않는 고용 요건", HttpStatus.INTERNAL_SERVER_ERROR.value()),
+    FAIL_POLICY_DATA_MAJOR("PC05", "정책 데이터 엔티티 변환 실패 : 존재하지 않는 전공 요건", HttpStatus.INTERNAL_SERVER_ERROR.value()),
+    FAIL_POLICY_DATA_SPECIALIZATION("PC06", "정책 데이터 엔티티 변환 실패 : 존재하지 않는 특화 요건", HttpStatus.INTERNAL_SERVER_ERROR.value()),
+    FAIL_POLICY_DATA_CATEGORY("PC07", "정책 데이터 엔티티 변환 실패 : 존재하지 않는 카테고리", HttpStatus.INTERNAL_SERVER_ERROR.value()),
+    FAIL_POLICY_DATA_SUB_CATEGORY("PC08", "정책 데이터 엔티티 변환 실패 : 존재하지 않는 하위 카테고리", HttpStatus.INTERNAL_SERVER_ERROR.value()),
 
     // Post
     POST_NOT_FOUND("PS01","해당 게시글을 찾을 수 없습니다.",HttpStatus.BAD_REQUEST.value()),

--- a/src/main/java/com/server/youthtalktalk/global/response/exception/policy/FailPolicyDataException.java
+++ b/src/main/java/com/server/youthtalktalk/global/response/exception/policy/FailPolicyDataException.java
@@ -1,0 +1,10 @@
+package com.server.youthtalktalk.global.response.exception.policy;
+
+import com.server.youthtalktalk.global.response.BaseResponseCode;
+import com.server.youthtalktalk.global.response.exception.BusinessException;
+
+public class FailPolicyDataException extends BusinessException {
+    public FailPolicyDataException(BaseResponseCode baseResponseCode) {
+        super(baseResponseCode);
+    }
+}

--- a/src/test/java/com/server/youthtalktalk/service/policy/PolicyDataServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/policy/PolicyDataServiceTest.java
@@ -1,32 +1,113 @@
 package com.server.youthtalktalk.service.policy;
 
+import com.server.youthtalktalk.domain.policy.dto.data.PolicyData;
+import com.server.youthtalktalk.domain.policy.entity.Policy;
 import com.server.youthtalktalk.domain.policy.service.data.PolicyDataService;
-import org.assertj.core.api.Assertions;
+import com.server.youthtalktalk.domain.policy.service.data.PolicyDataServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@Transactional
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static reactor.core.publisher.Mono.when;
+
+@ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
 public class PolicyDataServiceTest {
-    @Autowired
-    private PolicyDataService policyDataService;
+    @InjectMocks
+    private PolicyDataServiceImpl policyDataService;
+    @Mock
+    private PolicyData policyData;
 
-    @Test
-<<<<<<< HEAD
-    @DisplayName("정책 저장 성공")
-    void successSaveData(){
-//        policyDataService.saveData();
-=======
+    @BeforeEach
+    void init(){
+        policyData = PolicyData.builder()
+                .plcyNo("20250313005400210610")
+                .bscPlanCycl("1")
+                .bscPlanPlcyWayNo("002")
+                .bscPlanFcsAsmtNo("006")
+                .bscPlanAsmtNo("013")
+                .pvsnInstGroupCd("0054002")
+                .plcyPvsnMthdCd("0042013")
+                .plcyAprvSttsCd("0044002")
+                .plcyNm("청년 우대 반값 중개수수료 사업")
+                .plcyExplnCn("대학생 및 사회초년생의 경제적 부담 완화와 주거안정지원을 위하여 부동산 전‧월세 계약 시 중개수수료를 감면 서비스 제공")
+                .plcySprtCn("1. 대 상 자 : 부산 남구에 거주하거나 거주하려는 18~29세 1인 청년 가구\n2. 사업내용 : 지정된 중개업소에서 전‧월세 보증금 1억원 이하 임대차 계약시 중개수수료 50% 감면\n  * 지정 중개업소 확인 : 남구청 홈페이지(https://www.bsnamgu.go.kr/index.namgu?menuCd=DOM_000000125006020000)\n\n")
+                .sprvsnInstCd("3310000")
+                .sprvsnInstCdNm("남구")
+                .sprvsnInstPicNm("부동산관리팀")
+                .operInstCd("       ")
+                .operInstCdNm("")
+                .operInstPicNm("")
+                .sprtSclLmtYn("Y")
+                .aplyPrdSeCd("0057002")
+                .bizPrdSeCd("0056002")
+                .bizPrdBgngYmd("        ")
+                .bizPrdEndYmd("        ")
+                .bizPrdEtcCn("사업종료 시 별도 공지")
+                .plcyAplyMthdCn("")
+                .srngMthdCn("")
+                .aplyUrlAddr("")
+                .sbmsnDcmntCn("")
+                .etcMttrCn("")
+                .refUrlAddr1("https://www.bsnamgu.go.kr/index.namgu?menuCd=DOM_000000125006020000")
+                .refUrlAddr2("")
+                .sprtSclCnt("0")
+                .sprtArvlSeqYn("N")
+                .sprtTrgtMinAge("18")
+                .sprtTrgtMaxAge("29")
+                .sprtTrgtAgeLmtYn("N")
+                .mrgSttsCd("0055003")
+                .earnCndSeCd("0043001")
+                .earnMinAmt("0")
+                .earnMaxAmt("0")
+                .earnEtcCn("")
+                .addAplyQlfcCndCn("지정된 중개업소에서 전‧월세 보증금 1억원 이하 임대차 계약시 중개수수료 50% 감면")
+                .ptcpPrpTrgtCn("")
+                .inqCnt("52")
+                .rgtrInstCd("3310000")
+                .rgtrInstCdNm("부산광역시 남구")
+                .rgtrUpInstCd("6260000")
+                .rgtrUpInstCdNm("부산광역시")
+                .rgtrHghrkInstCd("6260000")
+                .rgtrHghrkInstCdNm("부산광역시")
+                .zipCd("26290")
+                .plcyMajorCd("0011009")
+                .jobCd("0013010")
+                .schoolCd("0049010")
+                .aplyYmd("")
+                .frstRegDt("2025-03-13 17:53:59")
+                .lastMdfcnDt("2025-03-14 09:34:49")
+                .sbizCd("0014010")
+                .build();
+    }
+
     @DisplayName("신청 기간 파싱 성공")
+    @Test
     void successParsingApplyDate(){
         String applyDate = "20250401 ~ 20250430\\N20250801 ~ 20250829";
         String[] dates = applyDate.split("\\\\N");
-        Assertions.assertThat(dates[0]).isEqualTo("20250401 ~ 20250430");
->>>>>>> dev/eunhye
+        assertThat(dates[0]).isEqualTo("20250401 ~ 20250430");
+    }
+
+    @DisplayName("예외 감지로 인한 정책 데이터 엔티티 변환 실패, 다른 데이터 이어서 변환 성공")
+    @Test
+    void successGetPolicyEntityListForOtherDataIfCatchException(){
+        // Given
+        PolicyData policyData2 = PolicyData.builder().build(); // 잘못된 데이터
+        List<PolicyData> policyDataList = Arrays.asList(policyData, policyData2);
+        // When
+        List<Policy> policyList = policyDataService.getPolicyEntityList(policyDataList);
+        // Then
+        assertThat(policyList).hasSize(1);
+        assertThat(policyList.get(0).getPolicyId()).isEqualTo(policyData.plcyNo());
     }
 }


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #12

### ⛳ 작업 분류
- [x] PolicyDataService : saveData() 호출 시 데이터를 저장하지 못하는 문제 해결
- [x] PolicyDataService : 온통청년 측 총 데이터 수와 일치하지 않는 문제 해결
- [x] Policy관련 : 검색 요건들의 예외처리 추가 

### 🔨 작업 상세 내용
1. 온통청년 측에서 발생하는 500 에러 문제  
- retryWhen()메서드로 500에러 감지 시 최대 5번 재호출하도록 구현
2. pageIndex가 너무 크게 증가하는 현상 
- 원인 : 개발자 실수로 파라미터 이름을 잘못 기입하는 바람에 기본 사이즈 10이 적용됨..
3. 온통청년 데이터 총 수와 불일치 하는 문제
- 원인 : 온통청년 측 서버 문제로 예상됨. 페이지 사이즈가 작을 수록 인덱스가 밀리는 현상이 생겨서 중복 데이터가 발생함. 중복 데이터는 데이터베이스에 저장 시 하나로 저장되기 때문에 우리 측 디비에는 더 적은 데이터가 저장될 수 밖에 없음.
- 페이지 사이즈를 크게 잡음으로써 일시적으로 해결함 (100개)
- 계속해서 사이즈 크기마다 해결이 될 때도 있고, 또 문제가 발생할 때도 있어서 이 부분은 온통청년측에 문의할 예정.
4. 검색 요건에 대한 데이터가 유효하지 않을 경우 예외가 발생하면서 정상 데이터도 저장이 되지 않는 문제
- saveData() : PolicyData의  toPolicy() 메서드에서 예외를 감지할 경우 해당 정책 데이터만 넘기고, 나머지 정상 데이터들은 이어서 정책 엔티티로 변환 후 디비에 저장되게끔 구현함.
- **기본값 처리** : 소득 요건, 결혼 요건은 제한없음, 기관 타입은 중앙부처, 지역은 전국(기존 방식)
- **예외 처리** : 전공, 특화, 고용, 학력, 카테고리, 하위 카테고리는 **FailPolicyDataException** 예외를 던짐

### 📍 참고 사항
- develop 브랜치에는 필요하지 않아서 삭제한 파일들이 아직 남아있는거 같습니다. merge 후 인텔리제이에서 빨간색으로 삭제된 파일이라고 뜨는 파일들은 삭제하셔도 좋습니다.
- 혹시 정책 데이터 패치 과정에서 기존 정책들을 모두 삭제 후 다시 패치하는게 필요하다면 적용해도 문제는 없어보입니다. Transactional을 적용했고, 기본적으로 스프링부트가 read-committed 격리 수준이라서 커밋되기 전에 사용자들한테 정책이 갑자기 다 사라져서 보이는 문제는 없을거 같아요.  
