### PR TITLE
[REFACTOR] Policy, PostDto 리팩토링 / PolicyData : SubCategory 삭제 / Department 테이블 생성

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/PolicyDetailResponseDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/PolicyDetailResponseDto.java
@@ -39,6 +39,7 @@ public class PolicyDetailResponseDto {
     private String refUrl2; // 참고 사이트 2
     private String formattedApplUrl; // 신청 사이트 (전처리)
     private Boolean isScrap;// 스크랩 여부
+    private String departmentImgUrl; // 중앙 부처 이미지
 //    private String policyId; // 정책 아이디
 //    private Region region; // 지역
 //    private Category category; // 카테고리
@@ -71,6 +72,7 @@ public class PolicyDetailResponseDto {
                 .refUrl2(policy.getRefUrl2()) // 참고 사이트 2
                 .formattedApplUrl(null) // 신청 사이트 (전처리)
                 .isScrap(isScrap)// 스크랩 여부
+                .departmentImgUrl(policy.getDepartment().getImage_url()) // 중앙부처 이미지 url
                 .build();
     }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/PolicyListResponseDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/PolicyListResponseDto.java
@@ -16,6 +16,7 @@ public class PolicyListResponseDto {
     private String deadlineStatus; // 마감 상태
     private String hostDep; // 주관 기관명
     private boolean isScrap; // 스크랩 여부
+    private String departmentImgUrl; // 중앙부처 이미지 url
 
     public static PolicyListResponseDto toListDto(Policy policy, Boolean isScrap) {
         return PolicyListResponseDto.builder()
@@ -25,6 +26,7 @@ public class PolicyListResponseDto {
                 .deadlineStatus(DeadlineStatusCalculator.calculateDeadline(policy.getApplyDue()))
                 .hostDep(policy.getHostDep())
                 .isScrap(isScrap)
+                .departmentImgUrl(policy.getDepartment().getImage_url())
                 .build();
     }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/SearchConditionDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/SearchConditionDto.java
@@ -1,0 +1,30 @@
+package com.server.youthtalktalk.domain.policy.dto;
+
+import com.server.youthtalktalk.domain.policy.entity.InstitutionType;
+import com.server.youthtalktalk.domain.policy.entity.SubCategory;
+import com.server.youthtalktalk.domain.policy.entity.condition.Education;
+import com.server.youthtalktalk.domain.policy.entity.condition.Employment;
+import com.server.youthtalktalk.domain.policy.entity.condition.Major;
+import com.server.youthtalktalk.domain.policy.entity.condition.Specialization;
+import com.server.youthtalktalk.domain.policy.entity.region.SubRegion;
+import com.server.youthtalktalk.domain.policy.entity.condition.Marriage;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record SearchConditionDto(
+        String keyword,
+        InstitutionType institutionType,
+        List<SubCategory> subCategories,
+        Marriage marriage,
+        Integer age,
+        Integer minEarn,
+        Integer maxEarn,
+        List<Education> educations,
+        List<Major> majors,
+        List<Employment> employments,
+        List<Specialization> specializations,
+        List<Long> subRegionIds,
+        Boolean isFinished
+        ) {
+}

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/DepartmentResponseDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/DepartmentResponseDto.java
@@ -1,0 +1,30 @@
+package com.server.youthtalktalk.domain.policy.dto.data;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+import java.util.List;
+
+@JacksonXmlRootElement(localName = "StanOrgCd")
+public record DepartmentResponseDto(@JacksonXmlProperty(localName = "head") Head head,
+                                    @JacksonXmlElementWrapper(useWrapping = false)
+                                    @JacksonXmlProperty(localName = "row") List<Row> row) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Head(
+            @JacksonXmlProperty(localName = "totalCount") Integer totalCount,
+            @JacksonXmlProperty(localName = "numOfRows") String numOfRows,
+            @JacksonXmlProperty(localName = "pageNo") String pageNo,
+            @JacksonXmlProperty(localName = "type") String type
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Row(
+            @JacksonXmlProperty(localName = "org_cd") String orgCd,
+            @JacksonXmlProperty(localName = "full_nm") String fullNm,
+            @JacksonXmlProperty(localName = "highst_cd") String highstCd,
+            @JacksonXmlProperty(localName = "rep_cd") String repCd
+    ) {}
+}

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
@@ -126,7 +126,6 @@ public record PolicyData(
                 .major(Major.findMajorList(plcyNo, plcyMajorCd))
                 .submitDoc(sbmsnDcmntCn)
                 .supportDetail(plcySprtCn)
-                .subCategory(SubCategory.fromKey(plcyNo, bscPlanFcsAsmtNo))
                 .earn(earn)
                 .maxEarn(earn.equals(Earn.ANNUL_INCOME) && !earnMaxAmt.isEmpty() ? Integer.parseInt(earnMaxAmt) : 0)
                 .minEarn(earn.equals(Earn.ANNUL_INCOME) && !earnMinAmt.isEmpty() ? Integer.parseInt(earnMinAmt) : 0)

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
@@ -74,7 +74,7 @@ public record PolicyData(
 ) {
     private static final String regionCode = "0054002";
 
-    public Policy toPolicy() {
+    public Policy toPolicy(Department department) {
         RepeatCode repeatCode = RepeatCode.fromKey(plcyNo, aplyPrdSeCd);
 
         // 신청 기간 파싱(상시인 경우 x)
@@ -134,6 +134,7 @@ public record PolicyData(
                 .zipCd(zipCd)
                 .bizStart(bizTerm[0])
                 .bizDue(bizTerm[1])
+                .department(department)
                 .build();
     }
 

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
@@ -135,6 +135,7 @@ public record PolicyData(
                 .bizStart(bizTerm[0])
                 .bizDue(bizTerm[1])
                 .department(department)
+                .hostDepCode(sprvsnInstCd)
                 .build();
     }
 

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/Department.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/Department.java
@@ -1,0 +1,27 @@
+package com.server.youthtalktalk.domain.policy.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+public class Department {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long departmentId;
+
+    @Column(nullable = false, length = 7, unique = true)
+    private String code;
+
+    @Column(nullable = false, length = 20)
+    private String name;
+
+    @Column(length = 300)
+    private String image_url;
+
+    @OneToMany(mappedBy = "department")
+    private List<Policy> policies = new ArrayList<>();
+}

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/Policy.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/Policy.java
@@ -134,6 +134,9 @@ public class Policy extends BaseTimeEntity {
     @JoinColumn(name = "department_id")
     private Department department;
 
+    @Column(length = 10)
+    private String hostDepCode;
+
     @Builder.Default
     @OneToMany(mappedBy = "policy")
     private List<Review> reviews = new ArrayList<>();

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/Policy.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/Policy.java
@@ -130,6 +130,10 @@ public class Policy extends BaseTimeEntity {
 
     private LocalDate bizDue; // 운영 종료일
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "department_id")
+    private Department department;
+
     @Builder.Default
     @OneToMany(mappedBy = "policy")
     private List<Review> reviews = new ArrayList<>();
@@ -141,4 +145,12 @@ public class Policy extends BaseTimeEntity {
     @Builder.Default
     @OneToMany(mappedBy = "policy", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PolicySubRegion> policySubRegions = new ArrayList<>();
+
+    /** 연관관계 메서드 */
+    void setDepartment(Department department) {
+        this.department = department;
+        if(department != null) {
+            department.getPolicies().add(this);
+        }
+    }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/Policy.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/Policy.java
@@ -21,7 +21,6 @@ import java.util.List;
 @AllArgsConstructor
 public class Policy extends BaseTimeEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private String policyId; // 정책 아이디
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/Policy.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/Policy.java
@@ -21,6 +21,7 @@ import java.util.List;
 @AllArgsConstructor
 public class Policy extends BaseTimeEntity {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private String policyId; // 정책 아이디
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/RepeatCode.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/RepeatCode.java
@@ -10,7 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 public enum RepeatCode {
     ALWAYS("0057002","상시"),
     PERIOD("0057001","특정기간"),
-    UNDEFINED("0057003","마감");
+    FINISHED("0057003","마감");
 
     private final String key;
     private final String name;
@@ -19,7 +19,7 @@ public enum RepeatCode {
         return switch (key) {
             case "0057001" -> RepeatCode.PERIOD;
             case "0057002" -> RepeatCode.ALWAYS;
-            case "0057003" -> RepeatCode.UNDEFINED;
+            case "0057003" -> RepeatCode.FINISHED;
             default -> {
                 log.error("[Policy Data] Not Existed RepeatCode = {}, policyId = {}", key, policyId);
                 yield RepeatCode.ALWAYS; // 값이 없는 경우 상시 처리

--- a/src/main/java/com/server/youthtalktalk/domain/policy/repository/DepartmentRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/repository/DepartmentRepository.java
@@ -1,0 +1,12 @@
+package com.server.youthtalktalk.domain.policy.repository;
+
+import com.server.youthtalktalk.domain.policy.entity.Department;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface DepartmentRepository extends JpaRepository<Department, Long> {
+    Optional<Department> findByCode(String code);
+}

--- a/src/main/java/com/server/youthtalktalk/domain/policy/repository/DepartmentRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/repository/DepartmentRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 @Repository
 public interface DepartmentRepository extends JpaRepository<Department, Long> {
     Optional<Department> findByCode(String code);
+    Optional<Department> findByName(String name);
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/data/PolicyDataService.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/data/PolicyDataService.java
@@ -1,16 +1,19 @@
 package com.server.youthtalktalk.domain.policy.service.data;
 
 import com.server.youthtalktalk.domain.policy.dto.data.PolicyData;
+import com.server.youthtalktalk.domain.policy.entity.Department;
 import com.server.youthtalktalk.domain.policy.entity.Policy;
 import com.server.youthtalktalk.domain.policy.entity.region.PolicySubRegion;
 import com.server.youthtalktalk.domain.policy.entity.region.Region;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 
 public interface PolicyDataService {
     void saveData();
-    List<PolicyData> fetchData();
+    List<PolicyData> fetchPolicyData();
+    Department searchDepartmentCode(String departmentCode, Department defaultDepartment);
     List<PolicySubRegion> setPolicySubRegions(Policy policy);
     Region searchRegionByZipCd(Policy policy);
-    List<Policy> getPolicyEntityList(List<PolicyData> policyDataList);
+    Mono<List<Policy>> getPolicyEntityList(List<PolicyData> policyDataList);
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/data/PolicyDataService.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/data/PolicyDataService.java
@@ -12,7 +12,7 @@ import java.util.List;
 public interface PolicyDataService {
     void saveData();
     List<PolicyData> fetchPolicyData();
-    Department searchDepartmentCode(String departmentCode, Department defaultDepartment);
+    Department searchDepartmentCode(String departmentCode, String departmentName, Department defaultDepartment);
     List<PolicySubRegion> setPolicySubRegions(Policy policy);
     Region searchRegionByZipCd(Policy policy);
     Mono<List<Policy>> getPolicyEntityList(List<PolicyData> policyDataList);

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/data/PolicyDataServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/data/PolicyDataServiceImpl.java
@@ -36,7 +36,7 @@ public class PolicyDataServiceImpl implements PolicyDataService {
 
     @Value("${youthpolicy.api.secret-key}")
     private String secretKey;
-    private static final int PAGE_SIZE = 100;
+    private static final int PAGE_SIZE = 27;
     private static final int LIMIT = 1000;
 
     @Override
@@ -47,17 +47,28 @@ public class PolicyDataServiceImpl implements PolicyDataService {
         List<PolicyData> policyDataList = fetchData();
         List<Policy> policyList = getPolicyEntityList(policyDataList);
 
-        log.info("[온통청년 Data Fetch] Fetched policies save to DB");
-        List<Policy> savedPolicyList = policyRepository.saveAll(policyList);
-        log.info("[온통청년 Data Fetch] Mapping with sub regions");
-        policySubRegionRepository.deleteAllByPolicyIn(savedPolicyList);
+        List<String> stringList = new ArrayList<>();
+        for(int i = 0; i < policyList.size(); i++) {
+            if(policyRepository.existsById(policyList.get(i).getPolicyId())) {
+                stringList.add(i + " " + policyList.get(i).getPolicyId());
+            }
+            policyRepository.save(policyList.get(i));
+        }
 
-        // 하위 지역 코드 매핑
-        List<PolicySubRegion> policySubRegionList = new ArrayList<>();
-        savedPolicyList.stream()
-                .filter(policy -> !policy.getRegion().equals(Region.ALL))
-                .forEach(policy -> policySubRegionList.addAll(setPolicySubRegions(policy)));
-        policySubRegionRepository.saveAll(policySubRegionList);
+        for(int i = 0; i < stringList.size(); i++) {
+            System.out.println(stringList.get(i));
+        }
+//        log.info("[온통청년 Data Fetch] Fetched policies save to DB");
+//        List<Policy> savedPolicyList = policyRepository.saveAll(policyList);
+//        log.info("[온통청년 Data Fetch] Mapping with sub regions");
+//        policySubRegionRepository.deleteAllByPolicyIn(savedPolicyList);
+//
+//        // 하위 지역 코드 매핑
+//        List<PolicySubRegion> policySubRegionList = new ArrayList<>();
+//        savedPolicyList.stream()
+//                .filter(policy -> !policy.getRegion().equals(Region.ALL))
+//                .forEach(policy -> policySubRegionList.addAll(setPolicySubRegions(policy)));
+//        policySubRegionRepository.saveAll(policySubRegionList);
     }
 
     @Override

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/data/PolicyDataServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/data/PolicyDataServiceImpl.java
@@ -36,7 +36,7 @@ public class PolicyDataServiceImpl implements PolicyDataService {
 
     @Value("${youthpolicy.api.secret-key}")
     private String secretKey;
-    private static final int PAGE_SIZE = 27;
+    private static final int PAGE_SIZE = 100;
     private static final int LIMIT = 1000;
 
     @Override
@@ -47,28 +47,17 @@ public class PolicyDataServiceImpl implements PolicyDataService {
         List<PolicyData> policyDataList = fetchData();
         List<Policy> policyList = getPolicyEntityList(policyDataList);
 
-        List<String> stringList = new ArrayList<>();
-        for(int i = 0; i < policyList.size(); i++) {
-            if(policyRepository.existsById(policyList.get(i).getPolicyId())) {
-                stringList.add(i + " " + policyList.get(i).getPolicyId());
-            }
-            policyRepository.save(policyList.get(i));
-        }
+        log.info("[온통청년 Data Fetch] Fetched policies save to DB");
+        List<Policy> savedPolicyList = policyRepository.saveAll(policyList);
+        log.info("[온통청년 Data Fetch] Mapping with sub regions");
+        policySubRegionRepository.deleteAllByPolicyIn(savedPolicyList);
 
-        for(int i = 0; i < stringList.size(); i++) {
-            System.out.println(stringList.get(i));
-        }
-//        log.info("[온통청년 Data Fetch] Fetched policies save to DB");
-//        List<Policy> savedPolicyList = policyRepository.saveAll(policyList);
-//        log.info("[온통청년 Data Fetch] Mapping with sub regions");
-//        policySubRegionRepository.deleteAllByPolicyIn(savedPolicyList);
-//
-//        // 하위 지역 코드 매핑
-//        List<PolicySubRegion> policySubRegionList = new ArrayList<>();
-//        savedPolicyList.stream()
-//                .filter(policy -> !policy.getRegion().equals(Region.ALL))
-//                .forEach(policy -> policySubRegionList.addAll(setPolicySubRegions(policy)));
-//        policySubRegionRepository.saveAll(policySubRegionList);
+        // 하위 지역 코드 매핑
+        List<PolicySubRegion> policySubRegionList = new ArrayList<>();
+        savedPolicyList.stream()
+                .filter(policy -> !policy.getRegion().equals(Region.ALL))
+                .forEach(policy -> policySubRegionList.addAll(setPolicySubRegions(policy)));
+        policySubRegionRepository.saveAll(policySubRegionList);
     }
 
     @Override

--- a/src/main/java/com/server/youthtalktalk/domain/post/dto/PostCreateTestReqDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/dto/PostCreateTestReqDto.java
@@ -13,11 +13,11 @@ import java.util.List;
 @Builder
 public class PostCreateTestReqDto {
     @NotBlank(message = "게시글 제목은 필수값입니다.")
-    @Size(max = 50,message = "게시글 제목은 최대 50자입니다.")
+    @Size(max = 50, message = "게시글 제목은 최대 50자입니다.")
     private String title;
 
-    @NotNull(message = "Content list cannot be null")
-    @Size(min = 1, message = "Content list must contain at least one item")
+    @NotNull(message = "게시글 본문 리스트는 필수값입니다.")
+    @Size(min = 1, message = "게시글 본문 리스트는 최소 1개 이상입니다.")
     private List<Content> contentList;
 
     private String postType; // 자유글 : null, 리뷰 : review

--- a/src/main/java/com/server/youthtalktalk/global/config/WebClientConfig.java
+++ b/src/main/java/com/server/youthtalktalk/global/config/WebClientConfig.java
@@ -1,0 +1,28 @@
+package com.server.youthtalktalk.global.config;
+
+import io.netty.channel.ChannelOption;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
+
+@Component
+public class WebClientConfig {
+    @Bean
+    public WebClient webClient() {
+        ConnectionProvider provider = ConnectionProvider.builder("client")
+                .maxConnections(100) // 최대 50개의 동시 연결 허용
+                .pendingAcquireMaxCount(1000) // 대기 중인 요청 개수 증가
+                .build();
+
+        HttpClient httpClient = HttpClient.create(provider)
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000); // 타임아웃 설정
+
+        return WebClient.builder()
+                .baseUrl("http://apis.data.go.kr/") // 기본 URL 설정
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+}

--- a/src/test/java/com/server/youthtalktalk/repository/policy/PolicyQueryRepositoryTest.java
+++ b/src/test/java/com/server/youthtalktalk/repository/policy/PolicyQueryRepositoryTest.java
@@ -1,0 +1,334 @@
+package com.server.youthtalktalk.repository.policy;
+
+import static com.server.youthtalktalk.domain.policy.entity.InstitutionType.*;
+import static com.server.youthtalktalk.domain.policy.entity.SubCategory.*;
+import static com.server.youthtalktalk.domain.policy.entity.condition.Earn.ANNUL_INCOME;
+import static com.server.youthtalktalk.domain.policy.entity.condition.Earn.OTHER;
+import static com.server.youthtalktalk.domain.policy.entity.condition.Earn.UNRESTRICTED;
+import static com.server.youthtalktalk.domain.policy.entity.condition.Education.UNIVERSITY_GRADUATED;
+import static com.server.youthtalktalk.domain.policy.entity.condition.Education.UNIVERSITY_GRADUATED_EXPECTED;
+import static com.server.youthtalktalk.domain.policy.entity.condition.Employment.EMPLOYED;
+import static com.server.youthtalktalk.domain.policy.entity.condition.Employment.FREELANCER;
+import static com.server.youthtalktalk.domain.policy.entity.condition.Major.BUSINESS;
+import static com.server.youthtalktalk.domain.policy.entity.condition.Major.SCIENCE;
+import static com.server.youthtalktalk.domain.policy.entity.condition.Marriage.SINGLE;
+import static com.server.youthtalktalk.domain.policy.entity.condition.Specialization.DISABLED;
+import static com.server.youthtalktalk.domain.policy.entity.condition.Specialization.SOLDIER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.server.youthtalktalk.domain.policy.dto.SearchConditionDto;
+import com.server.youthtalktalk.domain.policy.entity.InstitutionType;
+import com.server.youthtalktalk.domain.policy.entity.Policy;
+import com.server.youthtalktalk.domain.policy.entity.SubCategory;
+import com.server.youthtalktalk.domain.policy.entity.condition.Earn;
+import com.server.youthtalktalk.domain.policy.entity.condition.Education;
+import com.server.youthtalktalk.domain.policy.entity.condition.Employment;
+import com.server.youthtalktalk.domain.policy.entity.condition.Major;
+import com.server.youthtalktalk.domain.policy.entity.condition.Marriage;
+import com.server.youthtalktalk.domain.policy.entity.condition.Specialization;
+import com.server.youthtalktalk.domain.policy.entity.region.PolicySubRegion;
+import com.server.youthtalktalk.domain.policy.entity.region.Region;
+import com.server.youthtalktalk.domain.policy.entity.region.SubRegion;
+import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
+import com.server.youthtalktalk.domain.policy.repository.region.PolicySubRegionRepository;
+import com.server.youthtalktalk.domain.policy.repository.region.SubRegionRepository;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+public class PolicyQueryRepositoryTest {
+
+    @Autowired
+    private PolicyRepository policyRepository;
+
+    @Autowired
+    private PolicySubRegionRepository policySubRegionRepository;
+
+    @Autowired
+    private SubRegionRepository subRegionRepository;
+
+    @BeforeEach
+    void setUp() {
+        List<Policy> dummyPolicies = createDummyPolicies();
+        List<SubRegion> dummySubRegions = createDummySubRegions();
+        List<PolicySubRegion> dummyPolicySubRegions = createDummyPolicySubRegions(dummyPolicies, dummySubRegions);
+        subRegionRepository.saveAll(dummySubRegions);
+        policyRepository.saveAll(dummyPolicies);
+        policySubRegionRepository.saveAll(dummyPolicySubRegions);
+    }
+
+    /**
+     * 단일 조건 검색
+     */
+    @Test
+    @DisplayName("키워드 검색")
+    void testKeywordSearch() {
+        String keyword = "1";
+        SearchConditionDto condition = SearchConditionDto.builder().keyword(keyword).build();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+
+        long expectedCount = policyRepository.findAll().stream()
+                .filter(policy -> policy.getTitle().contains(keyword) || policy.getIntroduction().contains(keyword)).count();
+        assertThat(result.size()).isEqualTo(expectedCount);
+        assertThat(result).allMatch(policy -> policy.getIntroduction().contains(keyword) || policy.getTitle().contains(keyword));
+    }
+
+    @Test
+    @DisplayName("운영기관 타입으로 검색")
+    void testSearchByInstitutionType() {
+        SearchConditionDto condition = SearchConditionDto.builder().institutionType(CENTER).build();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+
+        long expectedCount = policyRepository.findAll().stream()
+                .filter(policy -> policy.getInstitutionType().equals(CENTER)).count();
+        assertThat(result.size()).isEqualTo(expectedCount);
+        assertThat(result).allMatch(policy -> policy.getInstitutionType() == CENTER);
+    }
+
+    @Test
+    @DisplayName("카테고리로 검색")
+    void testSearchByCategory() {
+        List<SubCategory> subCategories = List.of(JOB_CULTURE, JOB_SAFETY, JOB_EXPANSION, JOB_STARTUP, DWELLING_SUPPLY);
+        Set<SubCategory> subCategorySet = new HashSet<>(subCategories);
+        SearchConditionDto condition = SearchConditionDto.builder().subCategories(subCategories).build();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+
+        long expectedCount = policyRepository.findAll().stream()
+                .filter(policy -> policy.getSubCategory().equals(JOB_CULTURE) ||
+                        policy.getSubCategory().equals(JOB_SAFETY) ||
+                        policy.getSubCategory().equals(JOB_EXPANSION) ||
+                        policy.getSubCategory().equals(JOB_STARTUP) ||
+                        policy.getSubCategory().equals(DWELLING_SUPPLY))
+                .count();
+
+        assertThat(result.size()).isEqualTo(expectedCount);
+        assertThat(result).allMatch(data -> subCategorySet.contains(data.getSubCategory()));
+    }
+
+    @Test
+    @DisplayName("지역으로 검색")
+    void testSearchByRegions() {
+        List<SubRegion> allSubRegions = subRegionRepository.findAll();
+        List<Long> subRegionIds = List.of(allSubRegions.get(1), allSubRegions.get(3), allSubRegions.get(5)).stream()
+                .map(SubRegion::getId).toList();
+        SearchConditionDto condition = SearchConditionDto.builder().subRegionIds(subRegionIds).build();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+
+        long expectedCount = policyRepository.findAll().stream()
+                .filter(policy -> policy.getPolicySubRegions().stream()
+                        .anyMatch(psr -> subRegionIds.contains(psr.getSubRegion().getId())))
+                .count();
+
+        assertThat(result.size()).isEqualTo(expectedCount);
+        assertThat(result).allMatch(policy ->
+                policy.getPolicySubRegions().stream()
+                        .anyMatch(psr -> subRegionIds.contains(psr.getSubRegion().getId()))
+        );
+    }
+
+    @Test
+    @DisplayName("결혼요건으로 검색")
+    void testSearchByMarriage() {
+        SearchConditionDto condition = SearchConditionDto.builder().marriage(SINGLE).build();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+
+        long expectedCount = policyRepository.findAll().stream()
+                .filter(policy -> policy.getMarriage().equals(SINGLE)).count();
+        assertThat(result.size()).isEqualTo(expectedCount);
+        assertThat(result).allMatch(policy -> policy.getMarriage() == SINGLE);
+    }
+
+    @Test
+    @DisplayName("나이으로 검색")
+    void testSearchByAge() {
+        int age = 20;
+        SearchConditionDto condition = SearchConditionDto.builder().age(age).build();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+        long expectedCount = policyRepository.findAll().stream()
+                .filter(policy -> !policy.isLimitedAge() ||
+                        (policy.getMinAge() <= age && policy.getMaxAge() >= age))
+                .count();
+
+        assertThat(result.size()).isEqualTo(expectedCount);
+        assertThat(result).allMatch(policy -> policy.getMinAge() <= age && policy.getMaxAge() >= age);
+    }
+
+    @Test
+    @DisplayName("연소득으로 검색")
+    void testSearchByEarn() {
+        int minEarn = 1000;
+        int maxEarn = 2000;
+        SearchConditionDto condition = SearchConditionDto.builder().minEarn(minEarn).maxEarn(maxEarn).build();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+
+        long expectedCount = policyRepository.findAll().stream()
+                .filter(policy ->
+                        (policy.getEarn() == UNRESTRICTED || policy.getEarn() == OTHER) ||  // 제한이 없으면 무조건 포함
+                        (policy.getMinEarn() <= minEarn && policy.getMaxEarn() >= maxEarn) // 제한 있으면 조건 만족해야 포함
+                )
+                .count();
+
+        assertThat(result.size()).isEqualTo(expectedCount);
+        assertThat(result).allMatch(policy ->
+                !policy.isLimitedAge() || (policy.getMinAge() <= minEarn && policy.getMaxAge() >= maxEarn)
+        );
+    }
+
+    @Test
+    @DisplayName("학력으로 검색")
+    void testSearchByEducation() {
+        List<Education> educations = List.of(UNIVERSITY_GRADUATED, UNIVERSITY_GRADUATED_EXPECTED);
+        SearchConditionDto condition = SearchConditionDto.builder().educations(educations).build();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+
+        long expectedCount = policyRepository.findAll().stream()
+                .filter(policy -> policy.getEducation() != null &&
+                        policy.getEducation().stream().anyMatch(educations::contains)
+                )
+                .count();
+        assertThat(result.size()).isEqualTo(expectedCount);
+        assertThat(result).allMatch(
+                policy -> policy.getEducation() != null &&
+                        policy.getEducation().stream().anyMatch(educations::contains)
+        );
+    }
+
+    @Test
+    @DisplayName("전공요건으로 검색")
+    void testSearchByMajor() {
+        List<Major> majors = List.of(SCIENCE, BUSINESS);
+        SearchConditionDto condition = SearchConditionDto.builder().majors(majors).build();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+
+        long expectedCount = policyRepository.findAll().stream()
+                .filter(policy -> policy.getMajor() != null &&
+                        policy.getMajor().stream().anyMatch(majors::contains)
+                )
+                .count();
+        assertThat(result.size()).isEqualTo(expectedCount);
+        assertThat(result).allMatch(
+                policy -> policy.getMajor() != null &&
+                        policy.getMajor().stream().anyMatch(majors::contains)
+        );
+    }
+
+    @Test
+    @DisplayName("취업상태로 검색")
+    void testSearchByEmployment() {
+        List<Employment> employments = List.of(FREELANCER, EMPLOYED);
+        SearchConditionDto condition = SearchConditionDto.builder().employments(employments).build();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+
+        long expectedCount = policyRepository.findAll().stream()
+                .filter(policy -> policy.getEmployment() != null &&
+                        policy.getEmployment().stream().anyMatch(employments::contains)
+                )
+                .count();
+        assertThat(result.size()).isEqualTo(expectedCount);
+        assertThat(result).allMatch(
+                policy -> policy.getEmployment() != null &&
+                        policy.getEmployment().stream().anyMatch(employments::contains)
+        );
+    }
+
+    @Test
+    @DisplayName("특화분야로 검색")
+    void testSearchBySpecialization() {
+        List<Specialization> specializations = List.of(SOLDIER, DISABLED);
+        SearchConditionDto condition = SearchConditionDto.builder().specializations(specializations).build();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+
+        long expectedCount = policyRepository.findAll().stream()
+                .filter(policy -> policy.getSpecialization() != null &&
+                        policy.getSpecialization().stream().anyMatch(specializations::contains)
+                )
+                .count();
+        assertThat(result.size()).isEqualTo(expectedCount);
+        assertThat(result).allMatch(
+                policy -> policy.getSpecialization() != null &&
+                        policy.getSpecialization().stream().anyMatch(specializations::contains)
+        );
+    }
+
+    static List<Policy> createDummyPolicies() {
+        List<Policy> policies = new ArrayList<>();
+
+        InstitutionType[] institutionTypes = InstitutionType.values();
+        SubCategory[] subCategories = SubCategory.values();
+        Region[] regions = Region.values();
+        Marriage[] marriages = Marriage.values();
+        Education[] educations = Education.values();
+        Major[] majors = Major.values();
+        Employment[] employments = Employment.values();
+        Specialization[] specializations = Specialization.values();
+
+        for (int i = 0; i < 20; i++) {
+            Policy policy = Policy.builder()
+                    .policyId(UUID.randomUUID().toString())
+                    .isLimitedAge(true)
+                    .earn(ANNUL_INCOME)
+                    .institutionType(institutionTypes[i % institutionTypes.length])
+                    .title("청년 정책 " + i)
+                    .introduction("소개 내용 " + i)
+                    .region(regions[i % regions.length])
+                    .subCategory(subCategories[i % subCategories.length])
+                    .region(regions[i % regions.length])
+                    .marriage(marriages[i % marriages.length])
+                    .minAge(18 + (i % 6)) // 18~23
+                    .maxAge(29 + (i % 6)) // 29~34
+                    .minEarn(2000 + i * 100)
+                    .maxEarn(3000 + i * 100)
+                    .education(List.of(educations[i % educations.length]))
+                    .specialization(List.of(
+                            specializations[i % specializations.length],
+                            specializations[(i + 1) % specializations.length]
+                    ))
+                    .major(List.of(majors[i % majors.length], majors[(i + 2) % majors.length]))
+                    .employment(List.of(employments[i % employments.length]))
+                    .build();
+
+            policies.add(policy);
+        }
+
+        return policies;
+    }
+
+    private static List<SubRegion> createDummySubRegions() {
+        List<SubRegion> subRegions = new ArrayList<>();
+        Region[] regions = Region.values();
+        for (int i = 0; i < 10; i++) {
+            SubRegion subRegion = SubRegion.builder()
+                    .region(regions[i % regions.length])
+                    .name("subregion" + i)
+                    .code("code" + i)
+                    .build();
+            subRegions.add(subRegion);
+        }
+        return subRegions;
+    }
+
+    private static List<PolicySubRegion> createDummyPolicySubRegions(List<Policy> dummyPolicies, List<SubRegion> subRegions) {
+        List<PolicySubRegion> policySubRegions = new ArrayList<>();
+        for (int i = 0; i < dummyPolicies.size(); i++) {
+            SubRegion subRegion = subRegions.get(i % subRegions.size());
+            PolicySubRegion policySubRegion = PolicySubRegion.builder().build();
+            policySubRegion.setSubRegion(subRegion);
+            policySubRegion.setPolicy(dummyPolicies.get(i));
+            policySubRegions.add(policySubRegion);
+        }
+        return policySubRegions;
+    }
+}

--- a/src/test/java/com/server/youthtalktalk/service/policy/PolicyDataServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/policy/PolicyDataServiceTest.java
@@ -105,7 +105,7 @@ public class PolicyDataServiceTest {
         PolicyData policyData2 = PolicyData.builder().build(); // 잘못된 데이터
         List<PolicyData> policyDataList = Arrays.asList(policyData, policyData2);
         // When
-        List<Policy> policyList = policyDataService.getPolicyEntityList(policyDataList);
+        List<Policy> policyList = policyDataService.getPolicyEntityList(policyDataList).block();
         // Then
         assertThat(policyList).hasSize(1);
         assertThat(policyList.get(0).getPolicyId()).isEqualTo(policyData.plcyNo());


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #12 

### ⛳ 작업 분류
- [x] PolicyData : 하위 카테고리 삭제
- [x] Policy : strategy = GenerationType.IDENTITY 적용 
- [x] Department : 중앙부처 데이터 저장할 테이블 생성
- [x] PolicyDetailResponseDto, PolicyListResponseDto : 중앙부처 imgUrl 추가
- [x] PolicyDataService : 중앙부처 코드 매핑 API 연동 

### 🔨 작업 상세 내용
1. PolicyData : 하위 카테고리 저장 부분 삭제
2. Policy : GeneratedValue 어노테이션 적용
3. PostCreateTestReqDto : 메세지 한글로 통일
4. Department 테이블 생성 후 중앙부처 코드 데이터 삽입, 정책과 일대다 외래키로 연결
5. PolicyDataService : 중앙부처 코드 매핑 API 연동 완료했지만 속도 저하 문제로 인해 임시 주석 처리 상태
6. RepeatCode : Undefined -> Finished로 이름 변경(마감), DB 쿼리로 변경 필요!
```
alter table policy modify repeat_code enum('ALWAYS', 'PERIOD', 'UNDEFINED', 'FINISHED');

UPDATE policy SET repeat_code = 'FINISHED' WHERE repeat_code = 'UNDEFINED';

alter table policy modify repeat_code enum('ALWAYS', 'PERIOD', 'FINISHED');
```
### 📍 참고 사항
**중앙부처 코드 매핑 API 연동 과정**
1. **Department 테이블에 해당 코드가 존재하는지 확인** 후 존재하면 외래키 매핑
2. 존재하지 않는다면 중앙 부처 코드 API로 검색, **주관기관 코드의 상위 기관(대표 기관) 코드**로 Department 테이블 검색 후 매핑
3. 상위 기관 코드도 매핑이 안된다면 **기본 이미지 매핑**
**문제** : API 연동 후 10분 이내로 완료되던 패치 작업이 대략 2시간 이상 소요, API 요청 500번째부터 급격히 느려짐
**해결 과정** : Flux로 병렬 처리, Webclient 커넥션 풀 설정을 통해 동시 요청 개수, 대기 요청 수 조정
**적용 후** : 시간이 줄긴 했지만 여전히 1시간 이상 예상됨...
**예상 원인** : 혹시 DB I/O작업때문인가 싶어 DB 조회, 저장 작업은 모두 주석처리하고 API 요청 작업만 실행해봤는데 거의 비슷하게 느렸습니다. 아무래도 **API 요청 자체가 느린거 같습니다**. 온통청년 API와 다르게 중앙부처 API는 한번에 여러 개의 기관을 검색하지 못하고 하나씩 검색해야되고, 온통청년보다 상대적으로 속도도 느린 편이라 더 그런거 같아요 ㅠ