### PR TITLE
[FIX] 프로필 이미지 파일 최대 사이즈 변경 및 리팩토링

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/member/controller/MemberController.java
+++ b/src/main/java/com/server/youthtalktalk/domain/member/controller/MemberController.java
@@ -102,7 +102,11 @@ public class MemberController {
      */
     @DeleteMapping("/members/profile")
     public BaseResponse<String> deleteProfileImage() {
-        imageService.deleteProfileImage(memberService.getCurrentMember());
+        Member member = memberService.getCurrentMember();
+        if (member.getProfileImage() == null) {
+            return new BaseResponse<>(SUCCESS_EMPTY_PROFILE);
+        }
+        imageService.deleteProfileImage(member);
         return new BaseResponse<>(SUCCESS);
     }
 

--- a/src/main/java/com/server/youthtalktalk/domain/member/controller/MemberController.java
+++ b/src/main/java/com/server/youthtalktalk/domain/member/controller/MemberController.java
@@ -20,7 +20,7 @@ import static com.server.youthtalktalk.global.response.BaseResponseCode.*;
 @RequiredArgsConstructor
 public class MemberController {
 
-    private static final int MAX_PROFILE_SIZE = 1024 * 1024;
+    private static final int MAX_PROFILE_SIZE = 5 * 1024 * 1024; // 5MB
     private final MemberService memberService;
     private final ImageService imageService;
 
@@ -88,8 +88,8 @@ public class MemberController {
      * 프로필 이미지 등록 api
      */
     @PostMapping("/members/profile")
-    public BaseResponse<String> updateProfile(@RequestParam("image") MultipartFile image) throws IOException {
-        if (image.getSize() > MAX_PROFILE_SIZE) { // 1MB 용량 제한
+    public BaseResponse<String> uploadProfileImage(@RequestParam("image") MultipartFile image) throws IOException {
+        if (image.getSize() > MAX_PROFILE_SIZE) {
             return new BaseResponse<>(EXCEED_PROFILE_SIZE);
         }
         String imgUrl = imageService.uploadMultiFile(image);
@@ -101,7 +101,7 @@ public class MemberController {
      * 프로필 이미지 삭제 api
      */
     @DeleteMapping("/members/profile")
-    public BaseResponse<String> deleteProfile() {
+    public BaseResponse<String> deleteProfileImage() {
         imageService.deleteProfileImage(memberService.getCurrentMember());
         return new BaseResponse<>(SUCCESS);
     }

--- a/src/main/java/com/server/youthtalktalk/global/response/BaseResponseCode.java
+++ b/src/main/java/com/server/youthtalktalk/global/response/BaseResponseCode.java
@@ -50,7 +50,7 @@ public enum BaseResponseCode {
     BLOCK_DUPLICATED("M09", "이미 차단한 회원입니다.", HttpStatus.BAD_REQUEST.value()),
     NOT_BLOCKED_MEMBER("M10", "차단한 회원이 아닙니다.", HttpStatus.BAD_REQUEST.value()),
     INVALID_MEMBER_FOR_BLOCK("M11", "차단(해제)할 수 없는 회원입니다.", HttpStatus.BAD_REQUEST.value()),
-    EXCEED_PROFILE_SIZE("M12", "프로필 이미지는 최대 1MB까지 업로드할 수 있습니다.", HttpStatus.BAD_REQUEST.value()),
+    EXCEED_PROFILE_SIZE("M12", "프로필 이미지는 최대 5MB까지 업로드할 수 있습니다.", HttpStatus.BAD_REQUEST.value()),
 
     // Policy
     POLICY_NOT_FOUND("PC01","해당 정책을 찾을 수 없습니다.",HttpStatus.BAD_REQUEST.value()),

--- a/src/main/java/com/server/youthtalktalk/global/response/BaseResponseCode.java
+++ b/src/main/java/com/server/youthtalktalk/global/response/BaseResponseCode.java
@@ -26,6 +26,8 @@ public enum BaseResponseCode {
     SUCCESS_MEMBER_DELETE("S13", "회원 탈퇴를 완료하였습니다.", HttpStatus.OK.value()),
     SUCCESS_MEMBER_BLOCK("S14", "회원 차단에 성공했습니다.", HttpStatus.OK.value()),
     SUCCESS_MEMBER_UNBLOCK("S15", "차단 해제를 성공했습니다.", HttpStatus.OK.value()),
+    SUCCESS_EMPTY_PROFILE("S16", "등록된 프로필 이미지가 없습니다.", HttpStatus.OK.value()),
+
     // Announcement
     SUCCESS_ANNOUNCEMENT_CREATE("S16", "공지사항을 성공적으로 등록했습니다.", HttpStatus.OK.value()),
     SUCCESS_ANNOUNCEMENT_UPDATE("S17", "공지사항을 성공적으로 수정했습니다.", HttpStatus.OK.value()),


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #17 

### ⛳ 작업 분류
- [x] 프로필 이미지 파일 용량 5MB로 변경
- [x] 프로필 삭제 시 불필요한 DB 조회 방지하도록 리팩토링
- [x] API 명세서 업데이트 

### 🔨 작업 상세 내용
1. 프로필 이미지 등록 시 요청으로 받은 파일의 크기가 5MB를 초과하면 에러 메시지를 반환하도록 예외 처리했습니다. 
2. 기존 프로필 삭제 API는 회원이 프로필 이미지가 없더라도 우선 DB를 조회하는 로직이라서 불필요한 성능 저하가 발생하고 있었습니다. 따라서 회원의 프로필 이미지가 있는 경우에만 DB에서 이미지 검색 및 삭제를 진행하도록 코드를 개선했습니다. 

### 📍 참고 사항
- 관련 테스트 코드를 작성하지 않고 포스트맨으로 통합 테스트 진행했습니다.
- 4/3 개발 서버에 배포 완료했습니다.
