### PR TITLE
[FIX] 정책 검색 API에서 하위 카테고리 필터링 삭제

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/SearchConditionDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/SearchConditionDto.java
@@ -1,12 +1,11 @@
 package com.server.youthtalktalk.domain.policy.dto;
 
+import com.server.youthtalktalk.domain.policy.entity.Category;
 import com.server.youthtalktalk.domain.policy.entity.InstitutionType;
-import com.server.youthtalktalk.domain.policy.entity.SubCategory;
 import com.server.youthtalktalk.domain.policy.entity.condition.Education;
 import com.server.youthtalktalk.domain.policy.entity.condition.Employment;
 import com.server.youthtalktalk.domain.policy.entity.condition.Major;
 import com.server.youthtalktalk.domain.policy.entity.condition.Specialization;
-import com.server.youthtalktalk.domain.policy.entity.region.SubRegion;
 import com.server.youthtalktalk.domain.policy.entity.condition.Marriage;
 import java.util.List;
 import lombok.Builder;
@@ -15,7 +14,7 @@ import lombok.Builder;
 public record SearchConditionDto(
         String keyword,
         InstitutionType institutionType,
-        List<SubCategory> subCategories,
+        List<Category> categories,
         Marriage marriage,
         Integer age,
         Integer minEarn,

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/SearchConditionRequestDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/SearchConditionRequestDto.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 public class SearchConditionRequestDto {
     private String keyword; // 검색 키워드
     private String institutionType; // 담당기관 (중앙부처 또는 지자체)
-    private List<String> category; // 카테고리 (소분류 포함)
+    private List<String> category; // 카테고리
     private String marriage; // 결혼요건
     private String age; // 연령
     private String minEarn; // 최소 소득

--- a/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyQueryRepositoryImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyQueryRepositoryImpl.java
@@ -10,6 +10,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.server.youthtalktalk.domain.policy.dto.SearchConditionDto;
+import com.server.youthtalktalk.domain.policy.entity.Category;
 import com.server.youthtalktalk.domain.policy.entity.InstitutionType;
 import com.server.youthtalktalk.domain.policy.entity.Policy;
 import com.server.youthtalktalk.domain.policy.entity.QPolicy;
@@ -46,7 +47,7 @@ public class PolicyQueryRepositoryImpl implements PolicyQueryRepository {
 
         filterByKeyword(condition, policy, predicate); // 키워드
         predicate.and(eqInstitutionType(condition.institutionType())); // 운영기관
-        predicate.and(eqSubCategories(condition.subCategories())); // 카테고리
+        predicate.and(eqCategories(condition.categories())); // 카테고리
         predicate.and(eqMarriage(condition.marriage())); // 결혼 요건
         predicate.and(isAgeInRange(condition.age())); // 나이
         predicate.and(isEarnInRange(condition.minEarn(), condition.maxEarn())); // 소득 요건
@@ -93,13 +94,13 @@ public class PolicyQueryRepositoryImpl implements PolicyQueryRepository {
         return type != null ? policy.institutionType.eq(type) : null;
     }
 
-    private BooleanBuilder eqSubCategories(List<SubCategory> subCategories) {
-        if (subCategories == null || subCategories.isEmpty()) return null;
-        BooleanBuilder subCategoryPredicate = new BooleanBuilder();
-        for (SubCategory subCategory : subCategories) {
-            subCategoryPredicate.or(policy.subCategory.eq(subCategory));
+    private BooleanBuilder eqCategories(List<Category> categories) {
+        if (categories == null || categories.isEmpty()) return null;
+        BooleanBuilder categoryPredicate = new BooleanBuilder();
+        for (Category category : categories) {
+            categoryPredicate.or(policy.category.eq(category));
         }
-        return subCategoryPredicate;
+        return categoryPredicate;
     }
 
     private BooleanExpression eqMarriage(Marriage marriage) {

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyService.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyService.java
@@ -11,11 +11,11 @@ import java.util.List;
 public interface PolicyService {
 
 
-    public List<PolicyListResponseDto> getTop5Policies();
-    public List<PolicyListResponseDto> getPoliciesByCategories(List<Category> categories, Pageable pageable);
-    public SearchConditionResponseDto getPoliciesByCondition(SearchConditionRequestDto condition, Pageable pageable);
-    public List<SearchNameResponseDto> getPoliciesByName(String title, Pageable pageable);
-    public PolicyDetailResponseDto getPolicyDetail(String policyId);
+    List<PolicyListResponseDto> getTop5Policies();
+    List<PolicyListResponseDto> getPoliciesByCategories(List<Category> categories, Pageable pageable);
+    SearchConditionResponseDto getPoliciesByCondition(SearchConditionRequestDto condition, Pageable pageable);
+    List<SearchNameResponseDto> getPoliciesByName(String title, Pageable pageable);
+    PolicyDetailResponseDto getPolicyDetail(String policyId);
     Scrap scrapPolicy(String policyId, Member member);
     List<PolicyListResponseDto> getScrapPolicies(Pageable pageable,Member member);
 

--- a/src/test/java/com/server/youthtalktalk/repository/policy/PolicyQueryRepositoryTest.java
+++ b/src/test/java/com/server/youthtalktalk/repository/policy/PolicyQueryRepositoryTest.java
@@ -1,7 +1,8 @@
 package com.server.youthtalktalk.repository.policy;
 
+import static com.server.youthtalktalk.domain.policy.entity.Category.JOB;
+import static com.server.youthtalktalk.domain.policy.entity.Category.LIFE;
 import static com.server.youthtalktalk.domain.policy.entity.InstitutionType.*;
-import static com.server.youthtalktalk.domain.policy.entity.SubCategory.*;
 import static com.server.youthtalktalk.domain.policy.entity.condition.Earn.ANNUL_INCOME;
 import static com.server.youthtalktalk.domain.policy.entity.condition.Earn.OTHER;
 import static com.server.youthtalktalk.domain.policy.entity.condition.Earn.UNRESTRICTED;
@@ -17,10 +18,9 @@ import static com.server.youthtalktalk.domain.policy.entity.condition.Specializa
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.server.youthtalktalk.domain.policy.dto.SearchConditionDto;
+import com.server.youthtalktalk.domain.policy.entity.Category;
 import com.server.youthtalktalk.domain.policy.entity.InstitutionType;
 import com.server.youthtalktalk.domain.policy.entity.Policy;
-import com.server.youthtalktalk.domain.policy.entity.SubCategory;
-import com.server.youthtalktalk.domain.policy.entity.condition.Earn;
 import com.server.youthtalktalk.domain.policy.entity.condition.Education;
 import com.server.youthtalktalk.domain.policy.entity.condition.Employment;
 import com.server.youthtalktalk.domain.policy.entity.condition.Major;
@@ -33,9 +33,7 @@ import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
 import com.server.youthtalktalk.domain.policy.repository.region.PolicySubRegionRepository;
 import com.server.youthtalktalk.domain.policy.repository.region.SubRegionRepository;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -101,21 +99,17 @@ public class PolicyQueryRepositoryTest {
     @Test
     @DisplayName("카테고리로 검색")
     void testSearchByCategory() {
-        List<SubCategory> subCategories = List.of(JOB_CULTURE, JOB_SAFETY, JOB_EXPANSION, JOB_STARTUP, DWELLING_SUPPLY);
-        Set<SubCategory> subCategorySet = new HashSet<>(subCategories);
-        SearchConditionDto condition = SearchConditionDto.builder().subCategories(subCategories).build();
+        List<Category> categories = List.of(JOB, LIFE);
+        SearchConditionDto condition = SearchConditionDto.builder().categories(categories).build();
         List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
 
         long expectedCount = policyRepository.findAll().stream()
-                .filter(policy -> policy.getSubCategory().equals(JOB_CULTURE) ||
-                        policy.getSubCategory().equals(JOB_SAFETY) ||
-                        policy.getSubCategory().equals(JOB_EXPANSION) ||
-                        policy.getSubCategory().equals(JOB_STARTUP) ||
-                        policy.getSubCategory().equals(DWELLING_SUPPLY))
+                .filter(policy -> policy.getCategory().equals(JOB) ||
+                        policy.getCategory().equals(LIFE))
                 .count();
 
         assertThat(result.size()).isEqualTo(expectedCount);
-        assertThat(result).allMatch(data -> subCategorySet.contains(data.getSubCategory()));
+        assertThat(result).allMatch(data -> categories.contains(data.getCategory()));
     }
 
     @Test
@@ -267,7 +261,7 @@ public class PolicyQueryRepositoryTest {
         List<Policy> policies = new ArrayList<>();
 
         InstitutionType[] institutionTypes = InstitutionType.values();
-        SubCategory[] subCategories = SubCategory.values();
+        Category[] categories = Category.values();
         Region[] regions = Region.values();
         Marriage[] marriages = Marriage.values();
         Education[] educations = Education.values();
@@ -284,7 +278,7 @@ public class PolicyQueryRepositoryTest {
                     .title("청년 정책 " + i)
                     .introduction("소개 내용 " + i)
                     .region(regions[i % regions.length])
-                    .subCategory(subCategories[i % subCategories.length])
+                    .category(categories[i % categories.length])
                     .region(regions[i % regions.length])
                     .marriage(marriages[i % marriages.length])
                     .minAge(18 + (i % 6)) // 18~23


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #23 

### ⛳ 작업 분류
- [x] 관련 dto 수정 
- [x] 조건 적용 정책 조회 API의 서비스 코드 수정
- [x] 조건 적용 정책 조회 API의 레포지토리 코드 수정
- [x] 기존 테스트 코드 수정 

### 🔨 작업 상세 내용
1. SearchConditionDto, SearchConditionRequestDto에서 하위 카테고리 필드를 카테고리 필드로 변경했습니다.
2. 조건 적용 정책 조회 API의 서비스 코드와 레포지토리 코드에서 하위 카테고리 필터링 로직을 삭제 후 일반 카테고리(대분류)로만 필터링 되도록 수정했습니다.
3. 기존 테스트 코드도 수정 후 테스트 진행했습니다.

### 📍 참고 사항
- #16 와 충돌 가능성이 있어서 merge 하면서 확인이 필요합니다.
