### PR TITLE
[REFACTOR] Policy 엔티티 PK 변경

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/controller/CommentController.java
@@ -51,7 +51,7 @@ public class CommentController {
      * 정책 댓글 조회 api
      */
     @GetMapping("/policies/{policyId}/comments")
-    public BaseResponse<List<CommentDto>> getPolicyComments(@PathVariable String policyId) {
+    public BaseResponse<List<CommentDto>> getPolicyComments(@PathVariable Long policyId) {
         List<PolicyComment> policyComments = commentService.getPolicyComments(policyId);
         List<CommentDto> commentDtoList = commentService.toCommentDtoList(policyComments, memberService.getCurrentMember());
         return new BaseResponse<>(commentDtoList, SUCCESS);

--- a/src/main/java/com/server/youthtalktalk/domain/comment/dto/PolicyCommentCreateDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/dto/PolicyCommentCreateDto.java
@@ -1,10 +1,11 @@
 package com.server.youthtalktalk.domain.comment.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record PolicyCommentCreateDto(
-        @NotBlank(message = "policyId는 필수값입니다.")
-        String policyId,
+        @NotNull(message = "policyId는 필수값입니다.")
+        Long policyId,
         @NotBlank(message = "content는 필수값입니다.")
         String content
 ) {

--- a/src/main/java/com/server/youthtalktalk/domain/comment/dto/PolicyCommentDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/dto/PolicyCommentDto.java
@@ -1,4 +1,4 @@
 package com.server.youthtalktalk.domain.comment.dto;
 
-public record PolicyCommentDto(Long commentId, String nickname, String content, String policyId) implements MyCommentDto{
+public record PolicyCommentDto(Long commentId, String nickname, String content, Long policyId) implements MyCommentDto{
 }

--- a/src/main/java/com/server/youthtalktalk/domain/comment/entity/Comment.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/entity/Comment.java
@@ -52,5 +52,5 @@ public abstract class Comment extends BaseTimeEntity {
     }
 
     // 연관엔티티(post/policy) id 조회
-    public abstract Object getRelatedEntityId();
+    public abstract Long getRelatedEntityId();
 }

--- a/src/main/java/com/server/youthtalktalk/domain/comment/entity/PolicyComment.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/entity/PolicyComment.java
@@ -25,7 +25,7 @@ public class PolicyComment extends Comment{
     }
 
     @Override
-    public String getRelatedEntityId() {
+    public Long getRelatedEntityId() {
         return policy.getPolicyId();
     }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/repository/CommentRepository.java
@@ -20,7 +20,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     // 정책 댓글 조회 + 오래된 순 정렬
     @Query("SELECT pc FROM PolicyComment pc WHERE pc.policy.policyId = :policyId ORDER BY pc.createdAt ASC")
-    List<PolicyComment> findPolicyCommentsByPolicyIdOrderByCreatedAtAsc(@Param("policyId") String policyId);
+    List<PolicyComment> findPolicyCommentsByPolicyIdOrderByCreatedAtAsc(@Param("policyId") Long policyId);
 
     // 회원이 작성한 댓글 조회 + 최신 순 정렬
     List<Comment> findCommentsByWriterOrderByCreatedAtDesc(Member writer);

--- a/src/main/java/com/server/youthtalktalk/domain/comment/service/CommentService.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/service/CommentService.java
@@ -10,9 +10,9 @@ import com.server.youthtalktalk.domain.comment.dto.MyCommentDto;
 import java.util.List;
 
 public interface CommentService {
-    PolicyComment createPolicyComment(String policyId, String content, Member member);
+    PolicyComment createPolicyComment(Long policyId, String content, Member member);
     PostComment createPostComment(Long postId, String content, Member member);
-    List<PolicyComment> getPolicyComments(String policyId);
+    List<PolicyComment> getPolicyComments(Long policyId);
     List<PostComment> getPostComments(Long postId);
     List<Comment> getMyComments(Member member);
     List<Comment> getLikedComments(Member member);

--- a/src/main/java/com/server/youthtalktalk/domain/policy/controller/PolicyController.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/controller/PolicyController.java
@@ -45,7 +45,7 @@ public class PolicyController {
      * 특정 정책 세부 조회
      */
     @GetMapping("/policies/{id}")
-    public BaseResponse<PolicyDetailResponseDto> getPolicyDetail(@PathVariable String id) {
+    public BaseResponse<PolicyDetailResponseDto> getPolicyDetail(@PathVariable Long id) {
         PolicyDetailResponseDto policyDetail = policyService.getPolicyDetail(id);
         return new BaseResponse<>(policyDetail, BaseResponseCode.SUCCESS_POLICY_FOUND);
     }
@@ -54,7 +54,7 @@ public class PolicyController {
      * 정책 스크랩 API
      */
     @PostMapping("/policies/{id}/scrap")
-    public BaseResponse<String> scrap(@PathVariable String id){
+    public BaseResponse<String> scrap(@PathVariable Long id){
         if(policyService.scrapPolicy(id,memberService.getCurrentMember())!=null)
             return new BaseResponse<>(BaseResponseCode.SUCCESS_SCRAP);
         else

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/PolicyDetailResponseDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/PolicyDetailResponseDto.java
@@ -1,16 +1,8 @@
 package com.server.youthtalktalk.domain.policy.dto;
 
-import com.server.youthtalktalk.domain.policy.entity.*;
-import com.server.youthtalktalk.domain.policy.entity.condition.Education;
-import com.server.youthtalktalk.domain.policy.entity.condition.Employment;
-import com.server.youthtalktalk.domain.policy.entity.condition.Major;
-import com.server.youthtalktalk.domain.policy.entity.condition.Specialization;
-import com.server.youthtalktalk.domain.policy.entity.region.Region;
+import com.server.youthtalktalk.domain.policy.entity.Policy;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.time.LocalDate;
-import java.util.List;
 
 @Getter
 @Builder
@@ -39,7 +31,7 @@ public class PolicyDetailResponseDto {
     private String refUrl2; // 참고 사이트 2
     private String formattedApplUrl; // 신청 사이트 (전처리)
     private Boolean isScrap;// 스크랩 여부
-//    private String policyId; // 정책 아이디
+//    private Long policyId; // 정책 아이디
 //    private Region region; // 지역
 //    private Category category; // 카테고리
 //    private LocalDate applyDue; // 신청 마감일

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/PolicyListResponseDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/PolicyListResponseDto.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @Builder
 public class PolicyListResponseDto {
 
-    private String policyId; // 정책 아이디
+    private Long policyId; // 정책 아이디
     private Category category; // 카테고리
     private String title; // 정책명
     private String deadlineStatus; // 마감 상태

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/SearchNameResponseDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/SearchNameResponseDto.java
@@ -7,5 +7,5 @@ import lombok.Getter;
 @Builder
 public class SearchNameResponseDto {
     private String title;
-    private String policyId;
+    private Long policyId;
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
@@ -97,7 +97,7 @@ public record PolicyData(
         LocalDate[] bizTerm = parsingBizTerm();
 
         return Policy.builder()
-                .policyId(plcyNo)
+                .policyNum(plcyNo)
                 .region(region)
                 .title(plcyNm)
                 .institutionType(InstitutionType.fromKey(plcyNo, pvsnInstGroupCd))

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/Category.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/Category.java
@@ -19,7 +19,7 @@ public enum Category {
     private final String key;
     private final String name;
 
-    public static Category fromKey(String policyId, String key){
+    public static Category fromKey(String policyNum, String key){
         return switch(key){
             case "001" -> Category.JOB;
             case "002" -> Category.DWELLING;
@@ -27,7 +27,7 @@ public enum Category {
             case "004" -> Category.LIFE;
             case "005" -> Category.PARTICIPATION;
             default -> {
-                log.error("[Policy Data] Not Existed Category = {}, policyId = {}", key, policyId);
+                log.error("[Policy Data] Not Existed Category = {}, policyNum = {}", key, policyNum);
                 throw new FailPolicyDataException(BaseResponseCode.FAIL_POLICY_DATA_CATEGORY);
             }
         };

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/InstitutionType.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/InstitutionType.java
@@ -13,12 +13,12 @@ public enum InstitutionType {
 
     private final String key;
     // 담당 기관 타입 매핑
-    public static InstitutionType fromKey(String policyId, String key){
+    public static InstitutionType fromKey(String policyNum, String key){
         return switch (key) {
             case "0054001" -> InstitutionType.CENTER;
             case "0054002" -> InstitutionType.LOCAL;
             default -> {
-                log.error("[Policy Data] Not Existed InstitutionType = {}, policyId = {}", key, policyId);
+                log.error("[Policy Data] Not Existed InstitutionType = {}, policyNum = {}", key, policyNum);
                 yield InstitutionType.CENTER;
             }
         };

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/Policy.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/Policy.java
@@ -7,7 +7,6 @@ import com.server.youthtalktalk.domain.policy.entity.region.PolicySubRegion;
 import com.server.youthtalktalk.domain.policy.entity.region.Region;
 import com.server.youthtalktalk.domain.post.entity.Review;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -21,90 +20,111 @@ import java.util.List;
 @AllArgsConstructor
 public class Policy extends BaseTimeEntity {
     @Id
-    private String policyId; // 정책 아이디
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "policy_id", updatable = false)
+    private Long policyId;
+
+    @Column(name = "policy_num", length = 30, nullable = false, unique = true)
+    private String policyNum; // 정책 번호
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "region", length = 20)
     private Region region; // 지역
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "institutionType", length = 20)
     private InstitutionType institutionType; // 담당기관 구분(중앙부처, 지자체)
 
+    @Column(name = "title", length = 150)
     private String title; // 정책명
 
-    @Column(columnDefinition = "TEXT")
+    @Column(name = "introduction", columnDefinition = "TEXT")
     private String introduction; // 정책 소개
 
-    @Column(columnDefinition = "TEXT")
+    @Column(name = "supportDetail", columnDefinition = "TEXT")
     private String supportDetail; // 지원 내용
 
-    @Column(columnDefinition = "TEXT")
+    @Column(name = "applyTerm", columnDefinition = "TEXT")
     private String applyTerm; // 신청기간
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "repeatCode", length = 20)
     private RepeatCode repeatCode; // 신청 기간 반복 코드
 
+    @Column(name = "applyStart")
     private LocalDate applyStart; // 신청 시작일
 
+    @Column(name = "applyDue")
     private LocalDate applyDue; // 신청 마감일
 
-    private int minAge; // 최소 연령
+    @Column(name = "minAge")
+    private Integer minAge; // 최소 연령
 
-    private int maxAge; // 최대 연령
+    @Column(name = "maxAge")
+    private Integer maxAge; // 최대 연령
 
-    @Column(columnDefinition = "TEXT")
+    @Column(name = "addition", columnDefinition = "TEXT")
     private String addition; // 추가 사항
 
-    @Column(columnDefinition = "TEXT")
+    @Column(name = "applLimit", columnDefinition = "TEXT")
     private String applLimit; // 참여 제한 대상
 
-    @Column(columnDefinition = "TEXT")
+    @Column(name = "applStep", columnDefinition = "TEXT")
     private String applStep; // 신청 절차
 
-    @Column(columnDefinition = "TEXT")
+    @Column(name = "submitDoc", columnDefinition = "TEXT")
     private String submitDoc; // 제출 서류
 
-    @Column(columnDefinition = "TEXT")
+    @Column(name = "evaluation", columnDefinition = "TEXT")
     private String evaluation; // 평가 방법
 
-    @Column(length = 500)
+    @Column(name = "applUrl", length = 255)
     private String applUrl; // 신청 사이트
 
-    @Column(length = 500)
+    @Column(name = "refUrl1", length = 255)
     private String refUrl1; // 참고 사이트 1
 
-    @Column(length = 500)
+    @Column(name = "refUrl2", length = 255)
     private String refUrl2; // 참고 사이트 2
 
+    @Column(name = "hostDep", length = 255)
     private String hostDep; // 주관 부처명
 
+    @Column(name = "operatingOrg", length = 255)
     private String operatingOrg; // 운영 기관명
 
-    @Column(columnDefinition = "TEXT")
+    @Column(name = "etc", columnDefinition = "TEXT")
     private String etc; // 기타 사항
 
-    private long view; // 조회수
+    @Column(name = "view")
+    private Long view; // 조회수
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "category", length = 20)
     private Category category; // 카테고리
 
     /** 신규 필드 */
-    @NotNull
-    private boolean isLimitedAge;
+    @Column(name = "isLimitedAge")
+    private Boolean isLimitedAge;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "subCategory", length = 50)
     private SubCategory subCategory;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "earn", length = 20)
     private Earn earn; // 소득 제한 요건
 
-    private int minEarn; // 최소 소득
+    @Column(name = "minEarn")
+    private Integer minEarn; // 최소 소득
 
-    private int maxEarn; // 최대 소득
+    @Column(name = "maxEarn")
+    private Integer maxEarn; // 최대 소득
 
-    @Column(columnDefinition = "TEXT")
+    @Column(name = "earnEtc", columnDefinition = "TEXT")
     private String earnEtc; // 소득 기타 내용
 
-    @Column(columnDefinition = "TEXT")
+    @Column(name = "zipCd", columnDefinition = "TEXT")
     private String zipCd;
 
     @ElementCollection
@@ -120,14 +140,17 @@ public class Policy extends BaseTimeEntity {
     private List<Education> education; // 학력 요건
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "marriage", length = 255)
     private Marriage marriage; // 결혼 요건
 
     @ElementCollection
     @Enumerated(EnumType.STRING)
     private List<Employment> employment; // 취업 요건
 
+    @Column(name = "bizStart")
     private LocalDate bizStart; // 운영 시작일
 
+    @Column(name = "bizDue")
     private LocalDate bizDue; // 운영 종료일
 
     @Builder.Default

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/RepeatCode.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/RepeatCode.java
@@ -15,13 +15,13 @@ public enum RepeatCode {
     private final String key;
     private final String name;
 
-    public static RepeatCode fromKey(String policyId, String key){
+    public static RepeatCode fromKey(String policyNum, String key){
         return switch (key) {
             case "0057001" -> RepeatCode.PERIOD;
             case "0057002" -> RepeatCode.ALWAYS;
             case "0057003" -> RepeatCode.UNDEFINED;
             default -> {
-                log.error("[Policy Data] Not Existed RepeatCode = {}, policyId = {}", key, policyId);
+                log.error("[Policy Data] Not Existed RepeatCode = {}, policyId = {}", key, policyNum);
                 yield RepeatCode.ALWAYS; // 값이 없는 경우 상시 처리
             }
         };

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/SubCategory.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/SubCategory.java
@@ -1,14 +1,15 @@
 package com.server.youthtalktalk.domain.policy.entity;
 
-import static com.server.youthtalktalk.domain.policy.entity.Category.*;
-
-import java.util.ArrayList;
-import java.util.List;
 import com.server.youthtalktalk.global.response.BaseResponseCode;
 import com.server.youthtalktalk.global.response.exception.policy.FailPolicyDataException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.server.youthtalktalk.domain.policy.entity.Category.*;
 
 @Getter
 @RequiredArgsConstructor
@@ -39,13 +40,13 @@ public enum SubCategory {
     private final String name;
     private final Category category;
 
-    public static SubCategory fromKey(String policyId, String key) {
+    public static SubCategory fromKey(String policyNum, String key) {
         for (SubCategory subCategory : SubCategory.values()) {
             if (subCategory.getKey().equals(key)) {
                 return subCategory;
             }
         }
-        log.error("[Policy Data] Not Existed SubCategory = {} policyId = {}", key, policyId);
+        log.error("[Policy Data] Not Existed SubCategory = {} policyNum = {}", key, policyNum);
         throw new FailPolicyDataException(BaseResponseCode.FAIL_POLICY_DATA_SUB_CATEGORY);
     }
 

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Education.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Education.java
@@ -36,7 +36,7 @@ public enum Education {
         throw new FailPolicyDataException(BaseResponseCode.FAIL_POLICY_DATA_EDUCATION);
     }
 
-    public static List<Education> findEducationList(String policyId, String data){
+    public static List<Education> findEducationList(String policyNum, String data){
         String[] educations = data.split(",");
         Set<String> set = new HashSet<>();
         Collections.addAll(set, educations);
@@ -49,7 +49,7 @@ public enum Education {
         }
 
         if(set.size() != educationList.size()) {
-            log.error("[Policy Data] Not Existed Education = {} policyId = {}", data, policyId);
+            log.error("[Policy Data] Not Existed Education = {} policyNum = {}", data, policyNum);
             throw new FailPolicyDataException(BaseResponseCode.FAIL_POLICY_DATA_EDUCATION);
         }
         return educationList;

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Employment.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Employment.java
@@ -36,7 +36,7 @@ public enum Employment {
         throw new FailPolicyDataException(BaseResponseCode.FAIL_POLICY_DATA_EMPLOYMENT);
     }
 
-    public static List<Employment> findEmploymentList(String policyId, String data){
+    public static List<Employment> findEmploymentList(String policyNum, String data){
         String[] employments = data.split(",");
         Set<String> set = new HashSet<>();
         Collections.addAll(set, employments);
@@ -49,7 +49,7 @@ public enum Employment {
         }
 
         if(set.size() != employmentList.size()) {
-            log.error("[Policy Data] Not Existed Employment = {} policyId = {}", data, policyId);
+            log.error("[Policy Data] Not Existed Employment = {} policyNum = {}", data, policyNum);
             throw new FailPolicyDataException(BaseResponseCode.FAIL_POLICY_DATA_EMPLOYMENT);
         }
         return employmentList;

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Major.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Major.java
@@ -35,7 +35,7 @@ public enum Major {
         throw new FailPolicyDataException(BaseResponseCode.FAIL_POLICY_DATA_MAJOR);
     }
 
-    public static List<Major> findMajorList(String policyId, String data){
+    public static List<Major> findMajorList(String policyNum, String data){
         String[] majors = data.split(",");
         Set<String> set = new HashSet<>();
         Collections.addAll(set, majors);
@@ -48,7 +48,7 @@ public enum Major {
         }
 
         if(set.size() != majorList.size()) {
-            log.error("[Policy Data] Not Existed Major = {} policyId = {}", data, policyId);
+            log.error("[Policy Data] Not Existed Major = {} policyNum = {}", data, policyNum);
             throw new FailPolicyDataException(BaseResponseCode.FAIL_POLICY_DATA_MAJOR);
         }
         return majorList;

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Marriage.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Marriage.java
@@ -13,7 +13,7 @@ public enum Marriage {
     private final String key;
     private final String name;
 
-    public static Marriage fromKey(String policyId, String key) {
+    public static Marriage fromKey(String policyNum, String key) {
         return switch(key){
                 case "0055001" -> Marriage.MARRIED;
                 case "0055002" -> Marriage.SINGLE;

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Specialization.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Specialization.java
@@ -26,17 +26,17 @@ public enum Specialization {
     private final String key;
     private final String name;
 
-    public static Specialization fromKey(String policyId, String key) {
+    public static Specialization fromKey(String policyNum, String key) {
         for (Specialization specialization : Specialization.values()) {
             if (specialization.getKey().equals(key)) {
                 return specialization;
             }
         }
-        log.error("[Policy Data] Not Existed Specialization = {}, policyId = {}", key, policyId);
+        log.error("[Policy Data] Not Existed Specialization = {}, policyNum = {}", key, policyNum);
         throw new FailPolicyDataException(BaseResponseCode.FAIL_POLICY_DATA_SPECIALIZATION);
     }
 
-    public static List<Specialization> findSpecializationList(String policyId, String data){
+    public static List<Specialization> findSpecializationList(String policyNum, String data){
         String[] specializations = data.split(",");
         Set<String> set = new HashSet<>();
         Collections.addAll(set, specializations);
@@ -49,7 +49,7 @@ public enum Specialization {
         }
 
         if(set.size() != specializationList.size()) {
-            log.error("[Policy Data] Not Existed Specialization = {}, policyId = {}", data, policyId);
+            log.error("[Policy Data] Not Existed Specialization = {}, policyNum = {}", data, policyNum);
             throw new FailPolicyDataException(BaseResponseCode.FAIL_POLICY_DATA_SPECIALIZATION);
         }
         return specializationList;

--- a/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyRepository.java
@@ -27,20 +27,20 @@ public interface PolicyRepository extends JpaRepository<Policy,String>, PolicyQu
     /**
      * 카테고리별 정책 조회 (최신순) - 카테고리 중복 선택 가능
      */
-    @Query("SELECT p FROM Policy p WHERE (p.region = :region OR p.region = 'ALL') AND (p.category IN :categories) ORDER BY p.policyId DESC")
+    @Query("SELECT p FROM Policy p WHERE (p.region = :region OR p.region = 'ALL') AND (p.category IN :categories) ORDER BY p.policyNum DESC")
     Page<Policy> findByRegionAndCategory(@Param("region") Region region, @Param("categories") List<Category> categories, Pageable pageable);
 
     /**
      * 이름으로 정책 조회 (최신순)
      */
-    @Query("SELECT p FROM Policy p WHERE (p.region = :region OR p.region = 'ALL') AND  (REPLACE(p.title, ' ', '') LIKE CONCAT('%', :title, '%')) ORDER BY p.policyId DESC")
+    @Query("SELECT p FROM Policy p WHERE (p.region = :region OR p.region = 'ALL') AND  (REPLACE(p.title, ' ', '') LIKE CONCAT('%', :title, '%')) ORDER BY p.policyNum DESC")
     Page<Policy> findByRegionAndTitle(@Param("region") Region region, @Param("title") String title, Pageable pageable);
 
 
     /**
      * 특정 정책 조회
      */
-    Optional<Policy> findById(String policyId);
+    Optional<Policy> findByPolicyId(Long policyId);
 
     /**
      * 스크랩한 정책 조회(최신순)

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyService.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyService.java
@@ -15,8 +15,8 @@ public interface PolicyService {
     public List<PolicyListResponseDto> getPoliciesByCategories(List<Category> categories, Pageable pageable);
     public SearchConditionResponseDto getPoliciesByCondition(SearchConditionRequestDto condition, Pageable pageable);
     public List<SearchNameResponseDto> getPoliciesByName(String title, Pageable pageable);
-    public PolicyDetailResponseDto getPolicyDetail(String policyId);
-    Scrap scrapPolicy(String policyId, Member member);
+    public PolicyDetailResponseDto getPolicyDetail(Long policyId);
+    Scrap scrapPolicy(Long policyId, Member member);
     List<PolicyListResponseDto> getScrapPolicies(Pageable pageable,Member member);
 
     List<PolicyListResponseDto> getScrappedPoliciesWithUpcomingDeadline(Member member);

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
@@ -1,45 +1,23 @@
 package com.server.youthtalktalk.domain.policy.service;
 
-import static com.server.youthtalktalk.global.response.BaseResponseCode.INVALID_AGE;
-import static com.server.youthtalktalk.global.response.BaseResponseCode.INVALID_CATEGORY;
-import static com.server.youthtalktalk.global.response.BaseResponseCode.INVALID_EARN;
-import static com.server.youthtalktalk.global.response.BaseResponseCode.INVALID_EDUCATION;
-import static com.server.youthtalktalk.global.response.BaseResponseCode.INVALID_EMPLOYMENT;
-import static com.server.youthtalktalk.global.response.BaseResponseCode.INVALID_INSTITUTION_TYPE;
-import static com.server.youthtalktalk.global.response.BaseResponseCode.INVALID_KEYWORD;
-import static com.server.youthtalktalk.global.response.BaseResponseCode.INVALID_MAJOR;
-import static com.server.youthtalktalk.global.response.BaseResponseCode.INVALID_MARRIAGE;
-import static com.server.youthtalktalk.global.response.BaseResponseCode.INVALID_REGION;
-import static com.server.youthtalktalk.global.response.BaseResponseCode.INVALID_SPECIALIZATION;
-
 import com.server.youthtalktalk.domain.ItemType;
-import com.server.youthtalktalk.domain.policy.dto.SearchConditionDto;
+import com.server.youthtalktalk.domain.member.entity.Member;
+import com.server.youthtalktalk.domain.member.service.MemberService;
+import com.server.youthtalktalk.domain.policy.dto.*;
+import com.server.youthtalktalk.domain.policy.entity.Category;
 import com.server.youthtalktalk.domain.policy.entity.InstitutionType;
+import com.server.youthtalktalk.domain.policy.entity.Policy;
 import com.server.youthtalktalk.domain.policy.entity.SubCategory;
-import com.server.youthtalktalk.domain.policy.entity.condition.Education;
-import com.server.youthtalktalk.domain.policy.entity.condition.Employment;
-import com.server.youthtalktalk.domain.policy.entity.condition.Major;
-import com.server.youthtalktalk.domain.policy.entity.condition.Marriage;
-import com.server.youthtalktalk.domain.policy.entity.condition.Specialization;
+import com.server.youthtalktalk.domain.policy.entity.condition.*;
+import com.server.youthtalktalk.domain.policy.entity.region.Region;
 import com.server.youthtalktalk.domain.policy.entity.region.SubRegion;
+import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
 import com.server.youthtalktalk.domain.policy.repository.region.SubRegionRepository;
 import com.server.youthtalktalk.domain.scrap.entity.Scrap;
-import com.server.youthtalktalk.domain.member.entity.Member;
-import com.server.youthtalktalk.domain.policy.entity.Category;
-import com.server.youthtalktalk.domain.policy.entity.Policy;
-import com.server.youthtalktalk.domain.policy.entity.region.Region;
-import com.server.youthtalktalk.domain.policy.dto.*;
-import com.server.youthtalktalk.global.response.BaseResponseCode;
+import com.server.youthtalktalk.domain.scrap.repository.ScrapRepository;
 import com.server.youthtalktalk.global.response.exception.InvalidValueException;
 import com.server.youthtalktalk.global.response.exception.member.MemberNotFoundException;
 import com.server.youthtalktalk.global.response.exception.policy.PolicyNotFoundException;
-import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
-import com.server.youthtalktalk.domain.scrap.repository.ScrapRepository;
-import com.server.youthtalktalk.domain.member.service.MemberService;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.Set;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -48,9 +26,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
+
+import static com.server.youthtalktalk.global.response.BaseResponseCode.*;
 
 @Service
 @Slf4j
@@ -132,7 +111,7 @@ public class PolicyServiceImpl implements PolicyService {
      * 특정 정책 세부 조회
      */
     @Override
-    public PolicyDetailResponseDto getPolicyDetail(String policyId){
+    public PolicyDetailResponseDto getPolicyDetail(Long policyId){
         Long memberId;
         try {
             memberId = memberService.getCurrentMember().getId();
@@ -140,7 +119,7 @@ public class PolicyServiceImpl implements PolicyService {
             throw new MemberNotFoundException();
         }
 
-        Policy policy = policyRepository.findById(policyId)
+        Policy policy = policyRepository.findByPolicyId(policyId)
                 .orElseThrow(PolicyNotFoundException::new);
 
         policyRepository.save(policy.toBuilder().view(policy.getView()+1).build());
@@ -379,7 +358,7 @@ public class PolicyServiceImpl implements PolicyService {
         List<SearchNameResponseDto> result = policies.stream()
                 .map(policy -> {
                     String policyTitle = policy.getTitle();
-                    String policyId = policy.getPolicyId();
+                    Long policyId = policy.getPolicyId();
                     return SearchNameResponseDto.builder()
                             .policyId(policyId)
                             .title(policyTitle)
@@ -393,8 +372,8 @@ public class PolicyServiceImpl implements PolicyService {
 
 
     @Override
-    public Scrap scrapPolicy(String policyId, Member member) {
-        policyRepository.findById(policyId).orElseThrow(PolicyNotFoundException::new); // 정책 존재 유무
+    public Scrap scrapPolicy(Long policyId, Member member) {
+        policyRepository.findByPolicyId(policyId).orElseThrow(PolicyNotFoundException::new); // 정책 존재 유무
         Scrap scrap = scrapRepository.findByMemberAndItemIdAndItemType(member,policyId, ItemType.POLICY).orElse(null);
         if(scrap == null){
             return scrapRepository.save(Scrap.builder() // 스크랩할 경우

--- a/src/main/java/com/server/youthtalktalk/domain/post/dto/PostCreateReqDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/dto/PostCreateReqDto.java
@@ -16,6 +16,6 @@ public record PostCreateReqDto (
     @Size(min = 1, message = "Content list must contain at least one item")
     List<Content> contentList,
     String postType, // 자유글 : null, 리뷰 : review
-    String policyId  // 자유글 : null, 리뷰 : 해당 정책 아이디
+    Long policyId  // 자유글 : null, 리뷰 : 해당 정책 아이디
 ){
 }

--- a/src/main/java/com/server/youthtalktalk/domain/post/dto/PostCreateTestReqDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/dto/PostCreateTestReqDto.java
@@ -21,5 +21,5 @@ public class PostCreateTestReqDto {
     private List<Content> contentList;
 
     private String postType; // 자유글 : null, 리뷰 : review
-    private String policyId; // 자유글 : null, 리뷰 : 해당 정책 아이디
+    private Long policyId; // 자유글 : null, 리뷰 : 해당 정책 아이디
 }

--- a/src/main/java/com/server/youthtalktalk/domain/post/dto/PostListRepDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/dto/PostListRepDto.java
@@ -28,7 +28,7 @@ public class PostListRepDto {
         private int scraps;
         private boolean scrap;
         private int comments;
-        private String policyId; // 자유글 null
+        private Long policyId; // 자유글 null
         private String policyTitle; // 자유글 null
     }
 
@@ -41,7 +41,7 @@ public class PostListRepDto {
         private int scraps;
         private boolean scrap;
         private int comments;
-        private String policyId; // 자유글 null
+        private Long policyId; // 자유글 null
         private String policyTitle; // 자유글 null
         private Long scrapId;
     }

--- a/src/main/java/com/server/youthtalktalk/domain/post/dto/PostRepDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/dto/PostRepDto.java
@@ -13,7 +13,7 @@ public class PostRepDto {
     private String postType;
     private String title;
     private List<Content> contentList;
-    private String policyId; // 자유글 null
+    private Long policyId; // 자유글 null
     private String policyTitle; // 자유글 null
     private Long writerId;
     private String nickname;

--- a/src/main/java/com/server/youthtalktalk/domain/post/dto/PostUpdateReqDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/dto/PostUpdateReqDto.java
@@ -20,7 +20,7 @@ public class PostUpdateReqDto {
     @Size(min = 1, message = "게시글 본문은 필수값입니다.")
     private List<Content> contentList;
 
-    private String policyId; // 정책을 변경했을 때만
+    private Long policyId; // 정책을 변경했을 때만
     private List<String> addImgUrlList;
     private List<String> deletedImgUrlList;
 }

--- a/src/main/java/com/server/youthtalktalk/domain/post/dto/PostUpdateReqTestDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/dto/PostUpdateReqTestDto.java
@@ -20,7 +20,7 @@ public class PostUpdateReqTestDto {
     @Size(min = 1, message = "게시글 본문은 필수값입니다.")
     private List<Content> contentList;
 
-    private String policyId; // 정책을 변경했을 때만
+    private Long policyId; // 정책을 변경했을 때만
     private List<String> addImgUrlList;
     private List<String> deletedImgUrlList;
 }

--- a/src/main/java/com/server/youthtalktalk/domain/post/repostiory/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/repostiory/PostRepositoryCustomImpl.java
@@ -194,7 +194,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                 .selectFrom(post)
                 .leftJoin(block).on(blockJoinWithPost(member))
                 .leftJoin(report).on(reportJoinWithPost(member))
-                .join(scrap).on(post.id.stringValue().eq(scrap.itemId))
+                .join(scrap).on(post.id.eq(scrap.itemId))
                 .where(report.id.isNull().and(block.id.isNull()).and(scrap.member.eq(member)))
                 .orderBy(scrap.id.desc())
                 .offset(pageable.getOffset())
@@ -206,7 +206,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                 .from(post)
                 .leftJoin(block).on(blockJoinWithPost(member))
                 .leftJoin(report).on(reportJoinWithPost(member))
-                .join(scrap).on(post.id.stringValue().eq(scrap.itemId))
+                .join(scrap).on(post.id.eq(scrap.itemId))
                 .where(report.id.isNull().and(block.id.isNull()).and(scrap.member.eq(member)))
                 .fetchOne();
 

--- a/src/main/java/com/server/youthtalktalk/domain/post/service/PostReadServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/service/PostReadServiceImpl.java
@@ -1,23 +1,22 @@
 package com.server.youthtalktalk.domain.post.service;
 
 import com.server.youthtalktalk.domain.ItemType;
+import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.member.repository.BlockRepository;
+import com.server.youthtalktalk.domain.policy.entity.Category;
 import com.server.youthtalktalk.domain.post.dto.PostListRepDto;
+import com.server.youthtalktalk.domain.post.dto.PostRepDto;
+import com.server.youthtalktalk.domain.post.entity.Post;
+import com.server.youthtalktalk.domain.post.entity.Review;
+import com.server.youthtalktalk.domain.post.repostiory.PostRepository;
 import com.server.youthtalktalk.domain.post.repostiory.PostRepositoryCustom;
 import com.server.youthtalktalk.domain.report.repository.ReportRepository;
 import com.server.youthtalktalk.domain.scrap.entity.Scrap;
-import com.server.youthtalktalk.domain.member.entity.Member;
-import com.server.youthtalktalk.domain.policy.entity.Category;
-import com.server.youthtalktalk.domain.post.entity.Post;
-import com.server.youthtalktalk.domain.post.entity.Review;
-import com.server.youthtalktalk.domain.post.dto.PostRepDto;
+import com.server.youthtalktalk.domain.scrap.repository.ScrapRepository;
 import com.server.youthtalktalk.global.response.BaseResponseCode;
 import com.server.youthtalktalk.global.response.exception.InvalidValueException;
-import com.server.youthtalktalk.global.response.exception.member.MemberAccessDeniedException;
 import com.server.youthtalktalk.global.response.exception.post.BlockedMemberPostAccessDeniedException;
 import com.server.youthtalktalk.global.response.exception.post.PostNotFoundException;
-import com.server.youthtalktalk.domain.post.repostiory.PostRepository;
-import com.server.youthtalktalk.domain.scrap.repository.ScrapRepository;
 import com.server.youthtalktalk.global.response.exception.post.ReportedPostAccessDeniedException;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
@@ -26,7 +25,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -59,7 +57,7 @@ public class PostReadServiceImpl implements PostReadService {
 
         postRepository.save(post.toBuilder().view(post.getView()+1).build());
         log.info("게시글 조회 성공, postId = {}", postId);
-        return post.toPostRepDto(scrapRepository.existsByMemberIdAndItemIdAndItemType(member.getId(),post.getId().toString(),ItemType.POST));
+        return post.toPostRepDto(scrapRepository.existsByMemberIdAndItemIdAndItemType(member.getId(),post.getId(),ItemType.POST));
     }
 
     /** 게시글 전체 조회 */
@@ -144,13 +142,13 @@ public class PostReadServiceImpl implements PostReadService {
                 .policyId(post instanceof Review ? ((Review) post).getPolicy().getPolicyId() : null)
                 .policyTitle(post instanceof Review ? ((Review)post).getPolicy().getTitle() : null )
                 .comments(post.getPostComments().size())
-                .scrap(scrapRepository.existsByMemberIdAndItemIdAndItemType(member.getId(),post.getId().toString(),ItemType.POST))
-                .scraps(scrapRepository.findAllByItemIdAndItemType(post.getId().toString(), ItemType.POST).size())
+                .scrap(scrapRepository.existsByMemberIdAndItemIdAndItemType(member.getId(),post.getId(),ItemType.POST))
+                .scraps(scrapRepository.findAllByItemIdAndItemType(post.getId(), ItemType.POST).size())
                 .build();
     }
 
     public ScrapPostListDto toScrapPostDto(Post post, Member member) {
-        Scrap scrap = scrapRepository.findByMemberAndItemIdAndItemType(member,post.getId().toString(),ItemType.POST)
+        Scrap scrap = scrapRepository.findByMemberAndItemIdAndItemType(member,post.getId(),ItemType.POST)
                 .orElseThrow(EntityNotFoundException::new);
         return ScrapPostListDto.builder()
                 .postId(post.getId())
@@ -160,7 +158,7 @@ public class PostReadServiceImpl implements PostReadService {
                 .policyTitle(post instanceof Review ? ((Review)post).getPolicy().getTitle() : null )
                 .comments(post.getPostComments().size())
                 .scrap(true)
-                .scraps(scrapRepository.findAllByItemIdAndItemType(post.getId().toString(), ItemType.POST).size())
+                .scraps(scrapRepository.findAllByItemIdAndItemType(post.getId(), ItemType.POST).size())
                 .scrapId(scrap.getId())
                 .build();
     }

--- a/src/main/java/com/server/youthtalktalk/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/service/PostServiceImpl.java
@@ -1,30 +1,31 @@
 package com.server.youthtalktalk.domain.post.service;
 
 import com.server.youthtalktalk.domain.ItemType;
-import com.server.youthtalktalk.domain.scrap.entity.Scrap;
 import com.server.youthtalktalk.domain.image.entity.PostImage;
+import com.server.youthtalktalk.domain.image.service.ImageService;
 import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.policy.entity.Policy;
+import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
+import com.server.youthtalktalk.domain.post.dto.PostCreateReqDto;
+import com.server.youthtalktalk.domain.post.dto.PostRepDto;
+import com.server.youthtalktalk.domain.post.dto.PostUpdateReqDto;
 import com.server.youthtalktalk.domain.post.entity.Content;
 import com.server.youthtalktalk.domain.post.entity.ContentType;
 import com.server.youthtalktalk.domain.post.entity.Post;
 import com.server.youthtalktalk.domain.post.entity.Review;
-import com.server.youthtalktalk.domain.post.dto.*;
+import com.server.youthtalktalk.domain.post.repostiory.PostRepository;
+import com.server.youthtalktalk.domain.scrap.entity.Scrap;
+import com.server.youthtalktalk.domain.scrap.repository.ScrapRepository;
 import com.server.youthtalktalk.global.response.BaseResponseCode;
 import com.server.youthtalktalk.global.response.exception.BusinessException;
 import com.server.youthtalktalk.global.response.exception.InvalidValueException;
 import com.server.youthtalktalk.global.response.exception.policy.PolicyNotFoundException;
 import com.server.youthtalktalk.global.response.exception.post.PostNotFoundException;
-import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
-import com.server.youthtalktalk.domain.post.repostiory.PostRepository;
-import com.server.youthtalktalk.domain.scrap.repository.ScrapRepository;
-import com.server.youthtalktalk.domain.image.service.ImageService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -54,7 +55,7 @@ public class PostServiceImpl implements PostService{
                     .contents(postCreateReqDto.contentList())
                     .view(0L)
                     .build();
-            Policy policy = policyRepository.findById(postCreateReqDto.policyId()).orElseThrow(PolicyNotFoundException::new);
+            Policy policy = policyRepository.findByPolicyId(postCreateReqDto.policyId()).orElseThrow(PolicyNotFoundException::new);
             review.setPolicy(policy);
             post = review;
         }
@@ -66,13 +67,13 @@ public class PostServiceImpl implements PostService{
         // 이미지 리스트 추출 후 기존 PostImage 매핑
         imageService.mappingPostImage(extractImageUrl(post),post);
         log.info("게시글 생성 성공, postId = {}", savedPost.getId());
-        return savedPost.toPostRepDto(scrapRepository.existsByMemberIdAndItemIdAndItemType(writer.getId(),post.getId().toString(),ItemType.POST));
+        return savedPost.toPostRepDto(scrapRepository.existsByMemberIdAndItemIdAndItemType(writer.getId(),post.getId(),ItemType.POST));
     }
 
     @Override
     public PostRepDto updatePost(Long postId, PostUpdateReqDto postUpdateReqDto, Member writer){
         Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
-        if(post.getWriter()==null || post.getWriter().getId()!=writer.getId()){ // 작성자가 아닐 경우
+        if(post.getWriter() == null || post.getWriter().getId() != writer.getId()){ // 작성자가 아닐 경우
             throw new BusinessException(BaseResponseCode.POST_ACCESS_DENIED);
         }
 
@@ -81,8 +82,8 @@ public class PostServiceImpl implements PostService{
                 .contents(postUpdateReqDto.getContentList())
                 .build();
         if(post instanceof Review){ // 리뷰이면
-            if(postUpdateReqDto.getPolicyId()!=null&&!postUpdateReqDto.getPolicyId().isEmpty()){
-                Policy policy = policyRepository.findById(postUpdateReqDto.getPolicyId()).orElseThrow(PolicyNotFoundException::new);
+            if(postUpdateReqDto.getPolicyId() != null){
+                Policy policy = policyRepository.findByPolicyId(postUpdateReqDto.getPolicyId()).orElseThrow(PolicyNotFoundException::new);
                 ((Review)updatedPost).setPolicy(policy);
             }
         }
@@ -95,7 +96,7 @@ public class PostServiceImpl implements PostService{
             imageService.deleteMultiFile(postUpdateReqDto.getDeletedImgUrlList());
         }
         log.info("게시글 수정 성공, postId = {}", savedPost.getId());
-        return savedPost.toPostRepDto(scrapRepository.existsByMemberIdAndItemIdAndItemType(writer.getId(),post.getId().toString(),ItemType.POST));
+        return savedPost.toPostRepDto(scrapRepository.existsByMemberIdAndItemIdAndItemType(writer.getId(),post.getId(),ItemType.POST));
     }
 
     @Override
@@ -110,7 +111,7 @@ public class PostServiceImpl implements PostService{
                 .toList();
         imageService.deleteMultiFile(imageUrls);
         // 2. 게시글 스크랩 삭제
-        scrapRepository.deleteAllByItemIdAndItemType(post.getId().toString(), ItemType.POST);
+        scrapRepository.deleteAllByItemIdAndItemType(post.getId(), ItemType.POST);
         // 3. 게시글 삭제
         postRepository.delete(post);
         log.info("게시글 삭제 성공, postId = {}", postId);
@@ -119,14 +120,14 @@ public class PostServiceImpl implements PostService{
     @Override
     public Scrap scrapPost(Long postId, Member member) {
         postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
-        Scrap scrap = scrapRepository.findByMemberAndItemIdAndItemType(member,postId.toString(), ItemType.POST).orElse(null);
+        Scrap scrap = scrapRepository.findByMemberAndItemIdAndItemType(member, postId, ItemType.POST).orElse(null);
         if(scrap!=null){
             scrapRepository.delete(scrap);
             return null;
         }
         else{
             return scrapRepository.save(Scrap.builder() // 스크랩할 경우
-                    .itemId(postId.toString())
+                    .itemId(postId)
                     .itemType(ItemType.POST)
                     .member(member)
                     .build());

--- a/src/main/java/com/server/youthtalktalk/domain/scrap/entity/Scrap.java
+++ b/src/main/java/com/server/youthtalktalk/domain/scrap/entity/Scrap.java
@@ -21,14 +21,14 @@ public class Scrap {
     @Enumerated(EnumType.STRING)
     private ItemType itemType;
 
-    private String itemId;
+    private Long itemId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
     @Builder(toBuilder = true)
-    public Scrap(ItemType itemType, String itemId, Member member) {
+    public Scrap(ItemType itemType, Long itemId, Member member) {
         this.itemType = itemType;
         this.itemId = itemId;
         this.member = member;

--- a/src/main/java/com/server/youthtalktalk/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/scrap/repository/ScrapRepository.java
@@ -12,8 +12,8 @@ import java.util.Optional;
 @Repository
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     // 특정 사용자가 특정 타입의 아이템을 스크랩했는지의 여부
-    boolean existsByMemberIdAndItemIdAndItemType(Long memberId, String itemId, ItemType itemType);
-    Optional<Scrap> findByMemberAndItemIdAndItemType(Member memberId, String itemId, ItemType itemType);
-    List<Scrap> findAllByItemIdAndItemType(String itemId, ItemType itemType);
-    void deleteAllByItemIdAndItemType(String itemId, ItemType itemType);
+    boolean existsByMemberIdAndItemIdAndItemType(Long memberId, Long itemId, ItemType itemType);
+    Optional<Scrap> findByMemberAndItemIdAndItemType(Member memberId, Long itemId, ItemType itemType);
+    List<Scrap> findAllByItemIdAndItemType(Long itemId, ItemType itemType);
+    void deleteAllByItemIdAndItemType(Long itemId, ItemType itemType);
 }

--- a/src/main/java/com/server/youthtalktalk/global/response/BaseResponseCode.java
+++ b/src/main/java/com/server/youthtalktalk/global/response/BaseResponseCode.java
@@ -83,6 +83,7 @@ public enum BaseResponseCode {
     COMMENT_NOT_FOUND("C01", "해당 댓글을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST.value()),
     COMMENT_ALREADY_LIKED("C02", "이미 좋아요한 댓글입니다.", HttpStatus.BAD_REQUEST.value()),
     COMMENT_LIKE_NOT_FOUND("C03", "좋아요 정보가 없습니다.", HttpStatus.BAD_REQUEST.value()),
+    COMMENT_TYPE_UNKNOWN("C04", "알 수 없는 댓글 타입입니다.", HttpStatus.INTERNAL_SERVER_ERROR.value()),
 
     // Token
     INVALID_ACCESS_TOKEN("T01", "유효하지 않은 엑세스 토큰입니다.", HttpStatus.UNAUTHORIZED.value()),

--- a/src/test/java/com/server/youthtalktalk/repository/policy/PolicyQueryRepositoryTest.java
+++ b/src/test/java/com/server/youthtalktalk/repository/policy/PolicyQueryRepositoryTest.java
@@ -1,10 +1,33 @@
 package com.server.youthtalktalk.repository.policy;
 
-import static com.server.youthtalktalk.domain.policy.entity.InstitutionType.*;
+import com.server.youthtalktalk.domain.policy.dto.SearchConditionDto;
+import com.server.youthtalktalk.domain.policy.entity.InstitutionType;
+import com.server.youthtalktalk.domain.policy.entity.Policy;
+import com.server.youthtalktalk.domain.policy.entity.SubCategory;
+import com.server.youthtalktalk.domain.policy.entity.condition.*;
+import com.server.youthtalktalk.domain.policy.entity.region.PolicySubRegion;
+import com.server.youthtalktalk.domain.policy.entity.region.Region;
+import com.server.youthtalktalk.domain.policy.entity.region.SubRegion;
+import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
+import com.server.youthtalktalk.domain.policy.repository.region.PolicySubRegionRepository;
+import com.server.youthtalktalk.domain.policy.repository.region.SubRegionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.server.youthtalktalk.domain.policy.entity.InstitutionType.CENTER;
 import static com.server.youthtalktalk.domain.policy.entity.SubCategory.*;
-import static com.server.youthtalktalk.domain.policy.entity.condition.Earn.ANNUL_INCOME;
-import static com.server.youthtalktalk.domain.policy.entity.condition.Earn.OTHER;
-import static com.server.youthtalktalk.domain.policy.entity.condition.Earn.UNRESTRICTED;
+import static com.server.youthtalktalk.domain.policy.entity.condition.Earn.*;
 import static com.server.youthtalktalk.domain.policy.entity.condition.Education.UNIVERSITY_GRADUATED;
 import static com.server.youthtalktalk.domain.policy.entity.condition.Education.UNIVERSITY_GRADUATED_EXPECTED;
 import static com.server.youthtalktalk.domain.policy.entity.condition.Employment.EMPLOYED;
@@ -15,36 +38,6 @@ import static com.server.youthtalktalk.domain.policy.entity.condition.Marriage.S
 import static com.server.youthtalktalk.domain.policy.entity.condition.Specialization.DISABLED;
 import static com.server.youthtalktalk.domain.policy.entity.condition.Specialization.SOLDIER;
 import static org.assertj.core.api.Assertions.assertThat;
-
-import com.server.youthtalktalk.domain.policy.dto.SearchConditionDto;
-import com.server.youthtalktalk.domain.policy.entity.InstitutionType;
-import com.server.youthtalktalk.domain.policy.entity.Policy;
-import com.server.youthtalktalk.domain.policy.entity.SubCategory;
-import com.server.youthtalktalk.domain.policy.entity.condition.Earn;
-import com.server.youthtalktalk.domain.policy.entity.condition.Education;
-import com.server.youthtalktalk.domain.policy.entity.condition.Employment;
-import com.server.youthtalktalk.domain.policy.entity.condition.Major;
-import com.server.youthtalktalk.domain.policy.entity.condition.Marriage;
-import com.server.youthtalktalk.domain.policy.entity.condition.Specialization;
-import com.server.youthtalktalk.domain.policy.entity.region.PolicySubRegion;
-import com.server.youthtalktalk.domain.policy.entity.region.Region;
-import com.server.youthtalktalk.domain.policy.entity.region.SubRegion;
-import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
-import com.server.youthtalktalk.domain.policy.repository.region.PolicySubRegionRepository;
-import com.server.youthtalktalk.domain.policy.repository.region.SubRegionRepository;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
@@ -62,11 +55,22 @@ public class PolicyQueryRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        List<Policy> dummyPolicies = createDummyPolicies();
+//        List<Policy> dummyPolicies = createDummyPolicies();
+//        List<SubRegion> dummySubRegions = createDummySubRegions();
+//        List<PolicySubRegion> dummyPolicySubRegions = createDummyPolicySubRegions(dummyPolicies, dummySubRegions);
+//        subRegionRepository.saveAll(dummySubRegions);
+//        policyRepository.saveAll(dummyPolicies);
+//        policySubRegionRepository.saveAll(dummyPolicySubRegions);
+
         List<SubRegion> dummySubRegions = createDummySubRegions();
-        List<PolicySubRegion> dummyPolicySubRegions = createDummyPolicySubRegions(dummyPolicies, dummySubRegions);
         subRegionRepository.saveAll(dummySubRegions);
-        policyRepository.saveAll(dummyPolicies);
+
+        // 정책 먼저 저장 (실제 DB에 ID 생성됨)
+        List<Policy> dummyPolicies = createDummyPolicies();
+        List<Policy> savedPolicies = policyRepository.saveAll(dummyPolicies);
+
+        // 저장된 정책 사용해서 PolicySubRegion 생성
+        List<PolicySubRegion> dummyPolicySubRegions = createDummyPolicySubRegions(savedPolicies, dummySubRegions);
         policySubRegionRepository.saveAll(dummyPolicySubRegions);
     }
 
@@ -158,7 +162,7 @@ public class PolicyQueryRepositoryTest {
         SearchConditionDto condition = SearchConditionDto.builder().age(age).build();
         List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
         long expectedCount = policyRepository.findAll().stream()
-                .filter(policy -> !policy.isLimitedAge() ||
+                .filter(policy -> !policy.getIsLimitedAge() ||
                         (policy.getMinAge() <= age && policy.getMaxAge() >= age))
                 .count();
 
@@ -183,7 +187,7 @@ public class PolicyQueryRepositoryTest {
 
         assertThat(result.size()).isEqualTo(expectedCount);
         assertThat(result).allMatch(policy ->
-                !policy.isLimitedAge() || (policy.getMinAge() <= minEarn && policy.getMaxAge() >= maxEarn)
+                !policy.getIsLimitedAge() || (policy.getMinAge() <= minEarn && policy.getMaxAge() >= maxEarn)
         );
     }
 
@@ -277,7 +281,7 @@ public class PolicyQueryRepositoryTest {
 
         for (int i = 0; i < 20; i++) {
             Policy policy = Policy.builder()
-                    .policyId(UUID.randomUUID().toString())
+                    .policyNum("policyNum" + i)
                     .isLimitedAge(true)
                     .earn(ANNUL_INCOME)
                     .institutionType(institutionTypes[i % institutionTypes.length])

--- a/src/test/java/com/server/youthtalktalk/repository/post/PostRepositoryCustomTest.java
+++ b/src/test/java/com/server/youthtalktalk/repository/post/PostRepositoryCustomTest.java
@@ -14,10 +14,8 @@ import com.server.youthtalktalk.domain.post.entity.Post;
 import com.server.youthtalktalk.domain.post.entity.Review;
 import com.server.youthtalktalk.domain.post.repostiory.PostRepository;
 import com.server.youthtalktalk.domain.post.repostiory.PostRepositoryCustom;
-import com.server.youthtalktalk.domain.post.repostiory.PostRepositoryCustomImpl;
 import com.server.youthtalktalk.domain.report.repository.ReportRepository;
 import com.server.youthtalktalk.domain.scrap.repository.ScrapRepository;
-import com.server.youthtalktalk.global.config.QueryDSLConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,7 +30,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ActiveProfiles("test")
@@ -73,7 +71,7 @@ public class PostRepositoryCustomTest {
                 .build());
 
         this.policy = policyRepository.save(Policy.builder()
-                .policyId("policyId")
+                .policyNum("policyNum")
                 .title("policy1")
                 .category(Category.JOB)
                 .build());

--- a/src/test/java/com/server/youthtalktalk/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/comment/CommentServiceTest.java
@@ -61,7 +61,7 @@ class CommentServiceTest {
         Member member = Member.builder().username("member1").nickname("member1").region(Region.SEOUL).role(Role.USER).build();
         memberRepository.save(member);
 
-        Policy policy = Policy.builder().policyId("newPolicy").build();
+        Policy policy = Policy.builder().policyNum("policyNum").build();
         policyRepository.save(policy);
 
         String content = "policyComment_content";
@@ -78,7 +78,7 @@ class CommentServiceTest {
         assertThat(policyComment.getContent()).isEqualTo(content);
         assertThat(policyComment.getPolicy().getPolicyId()).isEqualTo(policy.getPolicyId());
 
-        Policy reloadedPolicy = policyRepository.findById(policy.getPolicyId()).orElseThrow();
+        Policy reloadedPolicy = policyRepository.findByPolicyId(policy.getPolicyId()).orElseThrow();
         assertThat(reloadedPolicy.getPolicyComments().size()).isEqualTo(1);
         assertThat(member.getComments().size()).isEqualTo(1);
     }
@@ -119,7 +119,7 @@ class CommentServiceTest {
 
         // when, then
         assertThrows(PolicyNotFoundException.class,
-                () -> commentService.createPolicyComment("notPolicyId", "content", member));
+                () -> commentService.createPolicyComment(123456L, "content", member));
     }
 
     @Test
@@ -139,7 +139,7 @@ class CommentServiceTest {
         Member member = Member.builder().username("member1").nickname("member1").region(Region.SEOUL).role(Role.USER).build();
         memberRepository.save(member);
 
-        Policy policy = Policy.builder().policyId("newPolicy").build();
+        Policy policy = Policy.builder().policyNum("policyNum").build();
         policyRepository.save(policy);
 
         PolicyComment policyComment1 = PolicyComment.builder().policy(policy).content("content1").writer(member).build();
@@ -185,7 +185,7 @@ class CommentServiceTest {
     void 정책_댓글_수정_성공() {
         // given
         Member member = Member.builder().username("member1").nickname("member1").region(Region.SEOUL).build();
-        Policy policy = Policy.builder().policyId("policy1").build();
+        Policy policy = Policy.builder().policyNum("policyNum").build();
         PolicyComment comment = PolicyComment.builder().content("content").build();
         comment.setWriter(member);
         comment.setPolicy(policy);

--- a/src/test/java/com/server/youthtalktalk/service/policy/PolicyDataServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/policy/PolicyDataServiceTest.java
@@ -2,7 +2,6 @@ package com.server.youthtalktalk.service.policy;
 
 import com.server.youthtalktalk.domain.policy.dto.data.PolicyData;
 import com.server.youthtalktalk.domain.policy.entity.Policy;
-import com.server.youthtalktalk.domain.policy.service.data.PolicyDataService;
 import com.server.youthtalktalk.domain.policy.service.data.PolicyDataServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,8 +15,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
-import static reactor.core.publisher.Mono.when;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
@@ -108,6 +106,6 @@ public class PolicyDataServiceTest {
         List<Policy> policyList = policyDataService.getPolicyEntityList(policyDataList);
         // Then
         assertThat(policyList).hasSize(1);
-        assertThat(policyList.get(0).getPolicyId()).isEqualTo(policyData.plcyNo());
+        assertThat(policyList.get(0).getPolicyNum()).isEqualTo(policyData.plcyNo());
     }
 }

--- a/src/test/java/com/server/youthtalktalk/service/post/PostReadServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/post/PostReadServiceTest.java
@@ -78,7 +78,7 @@ public class PostReadServiceTest {
         when(postRepository.findById(post.getId())).thenReturn(Optional.of(post));
         when(reportRepository.existsByPostAndReporter(post,member1)).thenReturn(false);
         when(blockRepository.existsByMemberAndBlockedMember(member1, post.getWriter())).thenReturn(false);
-        when(scrapRepository.existsByMemberIdAndItemIdAndItemType(member1.getId(),post.getId().toString(), ItemType.POST))
+        when(scrapRepository.existsByMemberIdAndItemIdAndItemType(member1.getId(),post.getId(), ItemType.POST))
                 .thenReturn(true);
         // When
         PostRepDto postRepDto = postReadService.getPostById(post.getId(),member1);
@@ -93,7 +93,7 @@ public class PostReadServiceTest {
         verify(postRepository).findById(post.getId());
         verify(reportRepository).existsByPostAndReporter(post,member1);
         verify(blockRepository).existsByMemberAndBlockedMember(member1,post.getWriter());
-        verify(scrapRepository).existsByMemberIdAndItemIdAndItemType(member1.getId(),post.getId().toString(), ItemType.POST);
+        verify(scrapRepository).existsByMemberIdAndItemIdAndItemType(member1.getId(),post.getId(), ItemType.POST);
     }
 
     @Test
@@ -142,9 +142,9 @@ public class PostReadServiceTest {
         // Given
         Member member = createMember("member",1L);
         Post post = createPost("post",1L, member, 10L);
-        when(scrapRepository.existsByMemberIdAndItemIdAndItemType(member.getId(),post.getId().toString(),ItemType.POST))
+        when(scrapRepository.existsByMemberIdAndItemIdAndItemType(member.getId(),post.getId(),ItemType.POST))
                 .thenReturn(true);
-        when(scrapRepository.findAllByItemIdAndItemType(post.getId().toString(), ItemType.POST))
+        when(scrapRepository.findAllByItemIdAndItemType(post.getId(), ItemType.POST))
                 .thenReturn(new ArrayList<>());
         // When
         PostListDto postListDto = postReadService.toPostDto(post, member);
@@ -157,8 +157,8 @@ public class PostReadServiceTest {
         assertThat(postListDto.getPolicyTitle()).isNull();
         assertThat(postListDto.getComments()).isEqualTo(0);
 
-        verify(scrapRepository).existsByMemberIdAndItemIdAndItemType(member.getId(),post.getId().toString(),ItemType.POST);
-        verify(scrapRepository).findAllByItemIdAndItemType(post.getId().toString(), ItemType.POST);
+        verify(scrapRepository).existsByMemberIdAndItemIdAndItemType(member.getId(),post.getId(),ItemType.POST);
+        verify(scrapRepository).findAllByItemIdAndItemType(post.getId(), ItemType.POST);
     }
 
     @Test
@@ -167,7 +167,7 @@ public class PostReadServiceTest {
         // Given
         Member member = createMember("member",1L);
         Policy policy = Policy.builder()
-                .policyId("policyId")
+                .policyNum("policyNum")
                 .title("policy")
                 .build();
         Review review = Review.builder()
@@ -177,9 +177,9 @@ public class PostReadServiceTest {
                 .title("review")
                 .writer(member)
                 .build();
-        when(scrapRepository.existsByMemberIdAndItemIdAndItemType(member.getId(),review.getId().toString(),ItemType.POST))
+        when(scrapRepository.existsByMemberIdAndItemIdAndItemType(member.getId(),review.getId(),ItemType.POST))
                 .thenReturn(true);
-        when(scrapRepository.findAllByItemIdAndItemType(review.getId().toString(), ItemType.POST))
+        when(scrapRepository.findAllByItemIdAndItemType(review.getId(), ItemType.POST))
                 .thenReturn(new ArrayList<>());
         // When
         PostListDto postListDto = postReadService.toPostDto(review, member);
@@ -188,12 +188,11 @@ public class PostReadServiceTest {
         assertThat(postListDto.getTitle()).isEqualTo("review");
         assertThat(postListDto.getWriterId()).isEqualTo(member.getId());
         assertThat(postListDto.isScrap()).isTrue();
-        assertThat(postListDto.getPolicyId()).isEqualTo("policyId");
         assertThat(postListDto.getPolicyTitle()).isEqualTo("policy");
         assertThat(postListDto.getComments()).isEqualTo(0);
 
-        verify(scrapRepository).existsByMemberIdAndItemIdAndItemType(member.getId(),review.getId().toString(),ItemType.POST);
-        verify(scrapRepository).findAllByItemIdAndItemType(review.getId().toString(), ItemType.POST);
+        verify(scrapRepository).existsByMemberIdAndItemIdAndItemType(member.getId(),review.getId(),ItemType.POST);
+        verify(scrapRepository).findAllByItemIdAndItemType(review.getId(), ItemType.POST);
     }
 
     @Test
@@ -240,7 +239,7 @@ public class PostReadServiceTest {
         // Given
         Member member = createMember("member",1L);
         Policy policy = Policy.builder()
-                .policyId("policyId")
+                .policyNum("policyNum")
                 .title("policy")
                 .category(Category.JOB)
                 .build();
@@ -301,7 +300,6 @@ public class PostReadServiceTest {
         // Given
         Member member = createMember("member",1L);
         Policy policy = Policy.builder()
-                .policyId("policyId")
                 .title("policy")
                 .category(Category.JOB)
                 .build();
@@ -366,11 +364,11 @@ public class PostReadServiceTest {
             Scrap scrap = Scrap.builder()
                     .member(member)
                     .itemType(ItemType.POST)
-                    .itemId(post.getId().toString())
+                    .itemId(post.getId())
                     .build();
-            when(scrapRepository.findByMemberAndItemIdAndItemType(member,post.getId().toString(),ItemType.POST))
+            when(scrapRepository.findByMemberAndItemIdAndItemType(member,post.getId(),ItemType.POST))
                     .thenReturn(Optional.of(scrap));
-            when(scrapRepository.findAllByItemIdAndItemType(post.getId().toString(), ItemType.POST))
+            when(scrapRepository.findAllByItemIdAndItemType(post.getId(), ItemType.POST))
                     .thenReturn(new ArrayList<>(List.of(scrap)));
         }
 
@@ -395,7 +393,7 @@ public class PostReadServiceTest {
         // Given
         Member member = createMember("member",1L);
         Policy policy = Policy.builder()
-                .policyId("policyId")
+                .policyNum("policyNum")
                 .title("policy")
                 .category(Category.JOB)
                 .build();
@@ -412,11 +410,11 @@ public class PostReadServiceTest {
             Scrap scrap = Scrap.builder()
                     .member(member)
                     .itemType(ItemType.POST)
-                    .itemId(post.getId().toString())
+                    .itemId(post.getId())
                     .build();
-            when(scrapRepository.findByMemberAndItemIdAndItemType(member,post.getId().toString(),ItemType.POST))
+            when(scrapRepository.findByMemberAndItemIdAndItemType(member,post.getId(),ItemType.POST))
                     .thenReturn(Optional.of(scrap));
-            when(scrapRepository.findAllByItemIdAndItemType(post.getId().toString(), ItemType.POST))
+            when(scrapRepository.findAllByItemIdAndItemType(post.getId(), ItemType.POST))
                     .thenReturn(new ArrayList<>(List.of(scrap)));
         }
 

--- a/src/test/java/com/server/youthtalktalk/service/post/PostServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/post/PostServiceTest.java
@@ -70,7 +70,7 @@ class PostServiceTest {
                 .build());
 
         this.policy = policyRepository.save(Policy.builder()
-                        .policyId("policyId")
+                        .policyNum("policyNum")
                         .title("policy1")
                         .category(Category.JOB)
                         .build());
@@ -119,7 +119,7 @@ class PostServiceTest {
     @DisplayName("존재하지 않는 정책일 경우 리뷰 생성 실패")
     void failCreateReviewIfNotExistPolicy(){
         // Given
-        PostCreateReqDto postCreateReqDto = new PostCreateReqDto("review", getContents(CONTENT, IMAGE_URL), "review", "notExistId");
+        PostCreateReqDto postCreateReqDto = new PostCreateReqDto("review", getContents(CONTENT, IMAGE_URL), "review", 9999L);
         // When
         // Then
         assertThatThrownBy(() -> postService.createPost(postCreateReqDto,this.member))
@@ -237,10 +237,11 @@ class PostServiceTest {
                 .title("review1")
                 .writer(member)
                 .contents(getContents(CONTENT, IMAGE_URL))
-                .build());
+                .build()); // policy 연결하지 않음
+        Long notExistPolicyId = 9999L;
         PostUpdateReqDto postUpdateReqDto = PostUpdateReqDto.builder()
                 .title("updatedTitle")
-                .policyId("notExistId")
+                .policyId(notExistPolicyId) // 존재하지 않는 정책 ID
                 .build();
         // When, Then
         assertThatThrownBy(()-> postService.updatePost(review.getId(), postUpdateReqDto, this.member))
@@ -281,10 +282,10 @@ class PostServiceTest {
     @DisplayName("게시글 스크랩 등록 / 취소 성공")
     void successScrapPostAndCancel(){
         postService.scrapPost(post.getId(), member); // 스크랩
-        assertThat(scrapRepository.existsByMemberIdAndItemIdAndItemType(member.getId(), post.getId().toString(), ItemType.POST)).isTrue();
+        assertThat(scrapRepository.existsByMemberIdAndItemIdAndItemType(member.getId(), post.getId(), ItemType.POST)).isTrue();
 
         postService.scrapPost(post.getId(), member); // 스크랩 취소
-        assertThat(scrapRepository.existsByMemberIdAndItemIdAndItemType(member.getId(), post.getId().toString(), ItemType.POST)).isFalse();
+        assertThat(scrapRepository.existsByMemberIdAndItemIdAndItemType(member.getId(), post.getId(), ItemType.POST)).isFalse();
     }
 
     @Test


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #20

### ⛳ 작업 분류
- [x] DB 구조 리팩토링
- [x] 테스트코드 수정

### 🔨 작업 상세 내용
1. policyId 필드 타입 String → Long 변경 및 자동 생성 전략 적용
2. 외부 정책 식별용 policyNum 필드 추가
3. 관련 Entity, Repository, DTO, Mapper 등 전반적인 필드 타입 수정
4. 기존 API 응답 및 요청 포맷에 맞춰 필드 수정 및 대응

### 📍 참고 사항
- 아직 DB 스키마 변경에 대한 적용 전인 상태입니다.
- 이 PR 이후에, fetch할 때 존재하는 정책이 있는지 검사하는 로직을 추가해서 다시 PR 올릴 예정입니다.