### PR TITLE
[FIX] 정책 검색 API - 정렬 기능 추가

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/policy/controller/PolicyController.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/controller/PolicyController.java
@@ -2,6 +2,7 @@ package com.server.youthtalktalk.domain.policy.controller;
 
 import com.server.youthtalktalk.domain.policy.entity.Category;
 import com.server.youthtalktalk.domain.policy.dto.*;
+import com.server.youthtalktalk.domain.policy.entity.SortOption;
 import com.server.youthtalktalk.global.response.BaseResponse;
 import com.server.youthtalktalk.global.response.BaseResponseCode;
 import com.server.youthtalktalk.domain.member.service.MemberService;
@@ -74,13 +75,17 @@ public class PolicyController {
      * 조건 적용 정책 조회
      */
     @PostMapping("/policies/search")
-    public BaseResponse<SearchConditionResponseDto> getPoliciesByCondition(@RequestBody SearchConditionRequestDto request,
-                                                                            @RequestParam(defaultValue = "10") int size,
-                                                                            @RequestParam(defaultValue = "0") int page) {
+    public BaseResponse<SearchConditionResponseDto> getPoliciesByCondition(
+            @RequestBody SearchConditionRequestDto request,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "RECENT") SortOption sort) {
+
         Pageable pageable = PageRequest.of(page, size);
-        SearchConditionResponseDto listResponseDto = policyService.getPoliciesByCondition(request, pageable);
-        if(listResponseDto.getPolicyList().isEmpty())
+        SearchConditionResponseDto listResponseDto = policyService.getPoliciesByCondition(request, pageable, sort);
+        if (listResponseDto.getPolicyList().isEmpty()) {
             return new BaseResponse<>(listResponseDto, BaseResponseCode.SUCCESS_POLICY_SEARCH_NO_RESULT);
+        }
         return new BaseResponse<>(listResponseDto, BaseResponseCode.SUCCESS_POLICY_FOUND);
     }
 

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
@@ -136,6 +136,7 @@ public record PolicyData(
                 .bizDue(bizTerm[1])
                 .department(department)
                 .hostDepCode(sprvsnInstCd)
+                .view(0L)
                 .build();
     }
 

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
@@ -136,7 +136,6 @@ public record PolicyData(
                 .bizDue(bizTerm[1])
                 .department(department)
                 .hostDepCode(sprvsnInstCd)
-                .view(0L)
                 .build();
     }
 

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/SortOption.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/SortOption.java
@@ -3,21 +3,24 @@ package com.server.youthtalktalk.domain.policy.entity;
 import static com.querydsl.core.types.Order.*;
 import static com.server.youthtalktalk.domain.policy.entity.QPolicy.policy;
 
-import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.dsl.ComparableExpressionBase;
 
 public enum SortOption {
-    RECENT(policy.policyId, DESC),
-    POPULAR(policy.view, DESC);
+    RECENT(new OrderSpecifier[]{
+            new OrderSpecifier<>(DESC, policy.policyNum)
+    }),
+    POPULAR(new OrderSpecifier[]{
+            new OrderSpecifier<>(DESC, policy.view), // 1순위 - 조회수 높은 순
+            new OrderSpecifier<>(DESC, policy.policyNum) // 2순위 - 최신순
+    });
 
-    private final OrderSpecifier<?> orderSpecifier;
+    private final OrderSpecifier<?>[] orderSpecifiers;
 
-    <T extends Comparable<?>> SortOption(ComparableExpressionBase<T> sortKey, Order order) {
-        this.orderSpecifier = new OrderSpecifier<>(order, sortKey);
+    SortOption(OrderSpecifier<?>[] orderSpecifiers) {
+        this.orderSpecifiers = orderSpecifiers;
     }
 
-    public OrderSpecifier<?> getOrderSpecifier() {
-        return orderSpecifier;
+    public OrderSpecifier<?>[] getOrderSpecifiers() {
+        return orderSpecifiers;
     }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/SortOption.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/SortOption.java
@@ -1,0 +1,23 @@
+package com.server.youthtalktalk.domain.policy.entity;
+
+import static com.querydsl.core.types.Order.*;
+import static com.server.youthtalktalk.domain.policy.entity.QPolicy.policy;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+
+public enum SortOption {
+    RECENT(policy.policyId, DESC),
+    POPULAR(policy.view, DESC);
+
+    private final OrderSpecifier<?> orderSpecifier;
+
+    <T extends Comparable<?>> SortOption(ComparableExpressionBase<T> sortKey, Order order) {
+        this.orderSpecifier = new OrderSpecifier<>(order, sortKey);
+    }
+
+    public OrderSpecifier<?> getOrderSpecifier() {
+        return orderSpecifier;
+    }
+}

--- a/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyQueryRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyQueryRepository.java
@@ -2,6 +2,7 @@ package com.server.youthtalktalk.domain.policy.repository;
 
 import com.server.youthtalktalk.domain.policy.dto.SearchConditionDto;
 import com.server.youthtalktalk.domain.policy.entity.Policy;
+import com.server.youthtalktalk.domain.policy.entity.SortOption;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -11,6 +12,6 @@ public interface PolicyQueryRepository {
     /**
      * 조건 적용 정책 조회
      */
-    Page<Policy> findByCondition(SearchConditionDto condition, Pageable pageable);
+    Page<Policy> findByCondition(SearchConditionDto condition, Pageable pageable, SortOption sortOption);
 
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyQueryRepositoryImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyQueryRepositoryImpl.java
@@ -14,7 +14,7 @@ import com.server.youthtalktalk.domain.policy.entity.Category;
 import com.server.youthtalktalk.domain.policy.entity.InstitutionType;
 import com.server.youthtalktalk.domain.policy.entity.Policy;
 import com.server.youthtalktalk.domain.policy.entity.QPolicy;
-import com.server.youthtalktalk.domain.policy.entity.SubCategory;
+import com.server.youthtalktalk.domain.policy.entity.SortOption;
 import com.server.youthtalktalk.domain.policy.entity.condition.Education;
 import com.server.youthtalktalk.domain.policy.entity.condition.Employment;
 import com.server.youthtalktalk.domain.policy.entity.condition.Major;
@@ -41,7 +41,7 @@ public class PolicyQueryRepositoryImpl implements PolicyQueryRepository {
      * 조건 적용 정책 조회
      */
     @Override
-    public Page<Policy> findByCondition(SearchConditionDto condition, Pageable pageable) {
+    public Page<Policy> findByCondition(SearchConditionDto condition, Pageable pageable, SortOption sortOption) {
         QPolicy policy = QPolicy.policy;
         BooleanBuilder predicate = new BooleanBuilder();
 
@@ -62,17 +62,18 @@ public class PolicyQueryRepositoryImpl implements PolicyQueryRepository {
         List<Policy> policies = queryFactory
                 .selectFrom(policy)
                 .where(predicate)
-                .orderBy(policy.policyId.desc())
+                .orderBy(sortOption.getOrderSpecifier())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
+        // 카운트 조회 쿼리
         long total = Optional.ofNullable(
                 queryFactory
-                    .select(policy.count())
-                    .from(policy)
-                    .where(predicate)
-                    .fetchOne()
+                        .select(policy.count())
+                        .from(policy)
+                        .where(predicate)
+                        .fetchOne()
         ).orElse(0L);
 
         return new PageImpl<>(policies, pageable, total);

--- a/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyQueryRepositoryImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyQueryRepositoryImpl.java
@@ -62,7 +62,7 @@ public class PolicyQueryRepositoryImpl implements PolicyQueryRepository {
         List<Policy> policies = queryFactory
                 .selectFrom(policy)
                 .where(predicate)
-                .orderBy(sortOption.getOrderSpecifier())
+                .orderBy(sortOption.getOrderSpecifiers())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyService.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyService.java
@@ -1,5 +1,6 @@
 package com.server.youthtalktalk.domain.policy.service;
 
+import com.server.youthtalktalk.domain.policy.entity.SortOption;
 import com.server.youthtalktalk.domain.scrap.entity.Scrap;
 import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.policy.entity.Category;
@@ -13,7 +14,7 @@ public interface PolicyService {
 
     List<PolicyListResponseDto> getTop5Policies();
     List<PolicyListResponseDto> getPoliciesByCategories(List<Category> categories, Pageable pageable);
-    SearchConditionResponseDto getPoliciesByCondition(SearchConditionRequestDto condition, Pageable pageable);
+    SearchConditionResponseDto getPoliciesByCondition(SearchConditionRequestDto condition, Pageable pageable, SortOption sortOption);
     List<SearchNameResponseDto> getPoliciesByName(String title, Pageable pageable);
     PolicyDetailResponseDto getPolicyDetail(String policyId);
     Scrap scrapPolicy(String policyId, Member member);

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
@@ -15,6 +15,7 @@ import static com.server.youthtalktalk.global.response.BaseResponseCode.INVALID_
 import com.server.youthtalktalk.domain.ItemType;
 import com.server.youthtalktalk.domain.policy.dto.SearchConditionDto;
 import com.server.youthtalktalk.domain.policy.entity.InstitutionType;
+import com.server.youthtalktalk.domain.policy.entity.SortOption;
 import com.server.youthtalktalk.domain.policy.entity.SubCategory;
 import com.server.youthtalktalk.domain.policy.entity.condition.Education;
 import com.server.youthtalktalk.domain.policy.entity.condition.Employment;
@@ -152,10 +153,10 @@ public class PolicyServiceImpl implements PolicyService {
     /**
      * 조건 적용 정책 조회
      */
-    public SearchConditionResponseDto getPoliciesByCondition(SearchConditionRequestDto conditionDto, Pageable pageable) {
+    public SearchConditionResponseDto getPoliciesByCondition(SearchConditionRequestDto conditionDto, Pageable pageable, SortOption sortOption) {
         SearchConditionDto searchCondition = setSearchCondition(conditionDto);
 
-        Page<Policy> policies = policyRepository.findByCondition(searchCondition, pageable);
+        Page<Policy> policies = policyRepository.findByCondition(searchCondition, pageable, sortOption);
         if (policies.isEmpty()) {
             log.info("조건에 맞는 정책이 존재하지 않습니다");
             return SearchConditionResponseDto.toListDto(Collections.emptyList(), 0L); // 빈 리스트 반환

--- a/src/test/java/com/server/youthtalktalk/repository/policy/PolicyQueryRepositoryTest.java
+++ b/src/test/java/com/server/youthtalktalk/repository/policy/PolicyQueryRepositoryTest.java
@@ -3,6 +3,7 @@ package com.server.youthtalktalk.repository.policy;
 import static com.server.youthtalktalk.domain.policy.entity.Category.JOB;
 import static com.server.youthtalktalk.domain.policy.entity.Category.LIFE;
 import static com.server.youthtalktalk.domain.policy.entity.InstitutionType.*;
+import static com.server.youthtalktalk.domain.policy.entity.SortOption.*;
 import static com.server.youthtalktalk.domain.policy.entity.condition.Earn.ANNUL_INCOME;
 import static com.server.youthtalktalk.domain.policy.entity.condition.Earn.OTHER;
 import static com.server.youthtalktalk.domain.policy.entity.condition.Earn.UNRESTRICTED;
@@ -21,6 +22,7 @@ import com.server.youthtalktalk.domain.policy.dto.SearchConditionDto;
 import com.server.youthtalktalk.domain.policy.entity.Category;
 import com.server.youthtalktalk.domain.policy.entity.InstitutionType;
 import com.server.youthtalktalk.domain.policy.entity.Policy;
+import com.server.youthtalktalk.domain.policy.entity.SortOption;
 import com.server.youthtalktalk.domain.policy.entity.condition.Education;
 import com.server.youthtalktalk.domain.policy.entity.condition.Employment;
 import com.server.youthtalktalk.domain.policy.entity.condition.Major;
@@ -49,6 +51,8 @@ import org.springframework.transaction.annotation.Transactional;
 @ActiveProfiles("test")
 public class PolicyQueryRepositoryTest {
 
+    private static final SortOption sortOption = RECENT;
+
     @Autowired
     private PolicyRepository policyRepository;
 
@@ -76,7 +80,7 @@ public class PolicyQueryRepositoryTest {
     void testKeywordSearch() {
         String keyword = "1";
         SearchConditionDto condition = SearchConditionDto.builder().keyword(keyword).build();
-        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE), sortOption).getContent();
 
         long expectedCount = policyRepository.findAll().stream()
                 .filter(policy -> policy.getTitle().contains(keyword) || policy.getIntroduction().contains(keyword)).count();
@@ -88,7 +92,7 @@ public class PolicyQueryRepositoryTest {
     @DisplayName("운영기관 타입으로 검색")
     void testSearchByInstitutionType() {
         SearchConditionDto condition = SearchConditionDto.builder().institutionType(CENTER).build();
-        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE), sortOption).getContent();
 
         long expectedCount = policyRepository.findAll().stream()
                 .filter(policy -> policy.getInstitutionType().equals(CENTER)).count();
@@ -101,7 +105,7 @@ public class PolicyQueryRepositoryTest {
     void testSearchByCategory() {
         List<Category> categories = List.of(JOB, LIFE);
         SearchConditionDto condition = SearchConditionDto.builder().categories(categories).build();
-        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE), sortOption).getContent();
 
         long expectedCount = policyRepository.findAll().stream()
                 .filter(policy -> policy.getCategory().equals(JOB) ||
@@ -119,7 +123,7 @@ public class PolicyQueryRepositoryTest {
         List<Long> subRegionIds = List.of(allSubRegions.get(1), allSubRegions.get(3), allSubRegions.get(5)).stream()
                 .map(SubRegion::getId).toList();
         SearchConditionDto condition = SearchConditionDto.builder().subRegionIds(subRegionIds).build();
-        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE), sortOption).getContent();
 
         long expectedCount = policyRepository.findAll().stream()
                 .filter(policy -> policy.getPolicySubRegions().stream()
@@ -137,7 +141,7 @@ public class PolicyQueryRepositoryTest {
     @DisplayName("결혼요건으로 검색")
     void testSearchByMarriage() {
         SearchConditionDto condition = SearchConditionDto.builder().marriage(SINGLE).build();
-        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE), sortOption).getContent();
 
         long expectedCount = policyRepository.findAll().stream()
                 .filter(policy -> policy.getMarriage().equals(SINGLE)).count();
@@ -150,7 +154,7 @@ public class PolicyQueryRepositoryTest {
     void testSearchByAge() {
         int age = 20;
         SearchConditionDto condition = SearchConditionDto.builder().age(age).build();
-        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE), sortOption).getContent();
         long expectedCount = policyRepository.findAll().stream()
                 .filter(policy -> !policy.isLimitedAge() ||
                         (policy.getMinAge() <= age && policy.getMaxAge() >= age))
@@ -166,7 +170,7 @@ public class PolicyQueryRepositoryTest {
         int minEarn = 1000;
         int maxEarn = 2000;
         SearchConditionDto condition = SearchConditionDto.builder().minEarn(minEarn).maxEarn(maxEarn).build();
-        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE), sortOption).getContent();
 
         long expectedCount = policyRepository.findAll().stream()
                 .filter(policy ->
@@ -186,7 +190,7 @@ public class PolicyQueryRepositoryTest {
     void testSearchByEducation() {
         List<Education> educations = List.of(UNIVERSITY_GRADUATED, UNIVERSITY_GRADUATED_EXPECTED);
         SearchConditionDto condition = SearchConditionDto.builder().educations(educations).build();
-        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE), sortOption).getContent();
 
         long expectedCount = policyRepository.findAll().stream()
                 .filter(policy -> policy.getEducation() != null &&
@@ -205,7 +209,7 @@ public class PolicyQueryRepositoryTest {
     void testSearchByMajor() {
         List<Major> majors = List.of(SCIENCE, BUSINESS);
         SearchConditionDto condition = SearchConditionDto.builder().majors(majors).build();
-        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE), sortOption).getContent();
 
         long expectedCount = policyRepository.findAll().stream()
                 .filter(policy -> policy.getMajor() != null &&
@@ -224,7 +228,7 @@ public class PolicyQueryRepositoryTest {
     void testSearchByEmployment() {
         List<Employment> employments = List.of(FREELANCER, EMPLOYED);
         SearchConditionDto condition = SearchConditionDto.builder().employments(employments).build();
-        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE), sortOption).getContent();
 
         long expectedCount = policyRepository.findAll().stream()
                 .filter(policy -> policy.getEmployment() != null &&
@@ -243,7 +247,7 @@ public class PolicyQueryRepositoryTest {
     void testSearchBySpecialization() {
         List<Specialization> specializations = List.of(SOLDIER, DISABLED);
         SearchConditionDto condition = SearchConditionDto.builder().specializations(specializations).build();
-        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+        List<Policy> result = policyRepository.findByCondition(condition, PageRequest.of(0, Integer.MAX_VALUE), sortOption).getContent();
 
         long expectedCount = policyRepository.findAll().stream()
                 .filter(policy -> policy.getSpecialization() != null &&
@@ -279,7 +283,6 @@ public class PolicyQueryRepositoryTest {
                     .introduction("소개 내용 " + i)
                     .region(regions[i % regions.length])
                     .category(categories[i % categories.length])
-                    .region(regions[i % regions.length])
                     .marriage(marriages[i % marriages.length])
                     .minAge(18 + (i % 6)) // 18~23
                     .maxAge(29 + (i % 6)) // 29~34


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #23 

### ⛳ 작업 분류
- [x] 정렬 기준을 정의하는 엔티티 SortOption 구현
- [x] 정책 검색 API의 컨트롤러, 서비스, 레포지토리 코드 수정
- [x] 인기순 정렬 시 조회 수가 같은 정책은 최신순으로 정렬하도록 수정 
- [x] 테스트 코드 구현
- [x] API 명세서 업데이트 

### 🔨 작업 상세 내용
1. 정렬 기준 필드와 방향을 속성으로 갖는 SortOption 객체를 Enum으로 구현했습니다.
    - 최신순 : PolicyNum 내림차순
    - 인기순 : view 내림차순 (1순위) + policyNum 내림차순 (2순위)  
2. 정책 검색 API 전반에서 정렬 기준이 적용되는 부분을 수정했습니다.
3. 인기순 정렬의 경우 조회수가 같으면 정렬 순서가 랜덤하게 (불확정적으로) 결정되기 때문에 조회수가 같은 정책에 대해서는  최신순으로 추가 정렬했습니다.
4. 인기순 정렬에 대하여 테스트 코드로 다음 케이스에 대하여 테스트했습니다.
    - 조회 수가 모두 다른 경우의 인기순 정렬
    - 조회 수가 같은 정책을 포함하는 경우의 인기순 정렬
5. 포스트맨 API 명세서 업데이트 완료했습니다.

### 📍 참고 사항
- 정책 생성 시 view 값이 null로 저장되어 정렬에 문제가 발생하여 기본값을 0으로 초기화하도록 수정했습니다. 
- 개발 서버에 배포는 아직 안 한 상태입니다. 개발 서버에 배포하면서 기존 DB 데이터의 view 값도 모두 0으로 쿼리로 초기화할 예정입니다.
