### PR TITLE
[FIX] 중앙 부처 API 호출 로직 수정, PolicyDataServiceTest 실패 수정

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
@@ -12,7 +12,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
 @Slf4j
-@Builder
+@Builder(toBuilder = true)
 public record PolicyData(
         String operInstCdNm,
         String bscPlanAsmtNo,

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/Department.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/Department.java
@@ -1,13 +1,16 @@
 package com.server.youthtalktalk.domain.policy.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
+@RequiredArgsConstructor
 public class Department {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,4 +27,12 @@ public class Department {
 
     @OneToMany(mappedBy = "department")
     private List<Policy> policies = new ArrayList<>();
+
+    @Builder
+    public Department(Long departmentId, String code, String name, String image_url) {
+        this.departmentId = departmentId;
+        this.code = code;
+        this.name = name;
+        this.image_url = image_url;
+    }
 }

--- a/src/test/java/com/server/youthtalktalk/service/policy/PolicyDataServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/policy/PolicyDataServiceTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.when;
 public class PolicyDataServiceTest {
     @InjectMocks
     private PolicyDataServiceImpl policyDataService;
-    @Mock
     private PolicyData policyData;
     @Mock
     private DepartmentRepository departmentRepository;
@@ -111,15 +110,17 @@ public class PolicyDataServiceTest {
     @Test
     void successGetPolicyEntityListForOtherDataIfCatchException(){
         // Given
-        PolicyData policyData2 = PolicyData.builder().sprvsnInstCd("").build(); // 잘못된 데이터
-        List<PolicyData> policyDataList = Arrays.asList(policyData2);
+        PolicyData validPolicyData = policyData.toBuilder().sprvsnInstCd("").build();
+        PolicyData invalidPolicyData = PolicyData.builder().sprvsnInstCd("").build(); // 잘못된 데이터
+        List<PolicyData> policyDataList = Arrays.asList(invalidPolicyData, validPolicyData);
         // When
         Department defaultDepartment = Department.builder().departmentId(1L).code("0000000").name("기본").image_url("").build();
 
         when(departmentRepository.findByCode(DEFAULT_DEPARTMENT)).thenReturn(Optional.of(defaultDepartment));
-        when(policyRepository.findByPolicyNum(policyData.plcyNo())).thenReturn(null);
+        when(policyRepository.findByPolicyNum(validPolicyData.plcyNo())).thenReturn(Optional.empty());
+        when(policyRepository.findByPolicyNum(invalidPolicyData.plcyNo())).thenReturn(Optional.empty());
         List<Policy> policyList = policyDataService.getPolicyEntityList(policyDataList).block();
         // Then
-        assertThat(policyList).hasSize(0);
+        assertThat(policyList).hasSize(1);
     }
 }

--- a/src/test/java/com/server/youthtalktalk/service/policy/PolicyDataServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/policy/PolicyDataServiceTest.java
@@ -1,7 +1,10 @@
 package com.server.youthtalktalk.service.policy;
 
 import com.server.youthtalktalk.domain.policy.dto.data.PolicyData;
+import com.server.youthtalktalk.domain.policy.entity.Department;
 import com.server.youthtalktalk.domain.policy.entity.Policy;
+import com.server.youthtalktalk.domain.policy.repository.DepartmentRepository;
+import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
 import com.server.youthtalktalk.domain.policy.service.data.PolicyDataServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,8 +17,11 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
@@ -24,6 +30,11 @@ public class PolicyDataServiceTest {
     private PolicyDataServiceImpl policyDataService;
     @Mock
     private PolicyData policyData;
+    @Mock
+    private DepartmentRepository departmentRepository;
+    @Mock
+    private PolicyRepository policyRepository;
+    private static final String DEFAULT_DEPARTMENT = "0";
 
     @BeforeEach
     void init(){
@@ -100,12 +111,15 @@ public class PolicyDataServiceTest {
     @Test
     void successGetPolicyEntityListForOtherDataIfCatchException(){
         // Given
-        PolicyData policyData2 = PolicyData.builder().build(); // 잘못된 데이터
-        List<PolicyData> policyDataList = Arrays.asList(policyData, policyData2);
+        PolicyData policyData2 = PolicyData.builder().sprvsnInstCd("").build(); // 잘못된 데이터
+        List<PolicyData> policyDataList = Arrays.asList(policyData2);
         // When
+        Department defaultDepartment = Department.builder().departmentId(1L).code("0000000").name("기본").image_url("").build();
+
+        when(departmentRepository.findByCode(DEFAULT_DEPARTMENT)).thenReturn(Optional.of(defaultDepartment));
+        when(policyRepository.findByPolicyNum(policyData.plcyNo())).thenReturn(null);
         List<Policy> policyList = policyDataService.getPolicyEntityList(policyDataList).block();
         // Then
-        assertThat(policyList).hasSize(1);
-        assertThat(policyList.get(0).getPolicyNum()).isEqualTo(policyData.plcyNo());
+        assertThat(policyList).hasSize(0);
     }
 }


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #12 

### ⛳ 작업 분류
- [x] PolicyDataService : 중앙 부처 API 호출 횟수 최적화
- [x] PolicyDataServiceTest : successGetPolicyEntityListForOtherDataIfCatchException() 실패 수정

### 🔨 작업 상세 내용
1. 기존 정책 데이터가 존재하고, 받아온 정책 데이터와 비교 시 주관기관이 변경되지 않았으면 중앙부처 API를 따로 호출하지 않습니다. 기존 Department 가져와서 그대로 매핑함으로써 API 호출 횟수를 최적화하였습니다.
2. successGetPolicyEntityListForOtherDataIfCatchException() : Department 관련 레포지토리 작업이 getPolicyEntityList()에 추가되면서, 유닛테스트이기 때문에 레포지토리 메서드 호출이 안되는 문제가 있었습니다. Mock객체를 생성해서 결과 값을 정하여 해결했습니다. 

### 📍 참고 사항
- 행정안전부 공공데이터 측에서 중앙부처 API 호출 100번 이하 제한 요청하였습니다. 기존 데이터가 존재하면 하루에 정책이 100개이상 생성되지 않는 이상 제한을 지킬 수 있습니다. 다만 데이터가 없는 상태에서 호출 시 최소 3000번 이상이므로 문제가 발생합니다.
