### PR TITLE
[FIX] 유효하지 않은 값 null 처리, nullable = false 처리

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
@@ -73,77 +73,83 @@ public record PolicyData(
         String rgtrHghrkInstCdNm
 ) {
     private static final String regionCode = "0054002";
+    private static final int DEFAULT_MIN_AGE = 0;
+    private static final int DEFAULT_MAX_AGE = 100;
+    private static final int DEFAULT_MIN_EARN = 0;
+    private static final int DEFAULT_MAX_EARN = 0;
 
     public Policy toPolicy(Department department) {
         RepeatCode repeatCode = RepeatCode.fromKey(plcyNo, aplyPrdSeCd);
 
-        // 신청 기간 파싱(상시인 경우 x)
-        if (aplyYmd.length() > 20) {
-            log.info("aplyYmd policyId = {}", plcyNo);
+        try {
+            // 신청 기간 파싱(상시인 경우 x)
+            if (aplyYmd.length() > 20) {
+                log.info("aplyYmd policyId = {}", plcyNo);
+            }
+
+            String[] dates = aplyYmd.split("\\\\N");
+            if (dates.length > 1 && !isEqualApplyDates(dates)) { // 서로 다른 신청 기간이 여러 개인 경우
+                repeatCode = RepeatCode.ALWAYS; // 상시 처리
+            }
+
+            LocalDate[] applyDates = parsingApplyYmd(dates[0]);
+            LocalDate applyStart = applyDates[0];
+            LocalDate applyDue = applyDates[1];
+
+            Earn earn = Earn.fromKey(plcyNo, earnCndSeCd);
+            Boolean isLimitedAge = sprtTrgtAgeLmtYn == null ? null : "N".equals(sprtTrgtAgeLmtYn);
+            Region region = findRegion();
+            LocalDate[] bizTerm = parsingBizTerm();
+
+            int minAge = parseAge(isLimitedAge, sprtTrgtMinAge, DEFAULT_MIN_AGE);
+            int maxAge = parseAge(isLimitedAge, sprtTrgtMaxAge, DEFAULT_MAX_AGE);
+            int maxEarn = parseEarn(earn, earnMaxAmt, DEFAULT_MAX_EARN);
+            int minEarn = parseEarn(earn, earnMinAmt, DEFAULT_MIN_EARN);
+
+            return Policy.builder()
+                    .policyNum(plcyNo)
+                    .region(region)
+                    .title(plcyNm)
+                    .institutionType(InstitutionType.fromKey(plcyNo, pvsnInstGroupCd))
+                    .isLimitedAge(isLimitedAge)
+                    .minAge(minAge)
+                    .maxAge(maxAge)
+                    .repeatCode(repeatCode)
+                    .applyTerm(aplyYmd)
+                    .applyStart(applyStart)
+                    .applyDue(applyDue)
+                    .addition(invalidToNull(addAplyQlfcCndCn))
+                    .etc(invalidToNull(etcMttrCn))
+                    .applLimit(invalidToNull(ptcpPrpTrgtCn))
+                    .applStep(invalidToNull(plcyAplyMthdCn))
+                    .applUrl(invalidToNull(aplyUrlAddr))
+                    .category(Category.fromKey(plcyNo, bscPlanPlcyWayNo))
+                    .education(Education.findEducationList(plcyNo, schoolCd))
+                    .employment(Employment.findEmploymentList(plcyNo, jobCd))
+                    .hostDep(invalidToNull(sprvsnInstCdNm))
+                    .refUrl1(invalidToNull(refUrlAddr1))
+                    .refUrl2(invalidToNull(refUrlAddr2))
+                    .evaluation(invalidToNull(srngMthdCn))
+                    .introduction(invalidToNull(plcyExplnCn))
+                    .operatingOrg(invalidToNull(operInstCdNm))
+                    .specialization(Specialization.findSpecializationList(plcyNo, sbizCd))
+                    .major(Major.findMajorList(plcyNo, plcyMajorCd))
+                    .submitDoc(invalidToNull(sbmsnDcmntCn))
+                    .supportDetail(invalidToNull(plcySprtCn))
+                    .earn(earn)
+                    .maxEarn(maxEarn)
+                    .minEarn(minEarn)
+                    .earnEtc(invalidToNull(earnEtcCn))
+                    .marriage(Marriage.fromKey(plcyNo, mrgSttsCd))
+                    .zipCd(invalidToNull(zipCd))
+                    .bizStart(bizTerm[0])
+                    .bizDue(bizTerm[1])
+                    .department(department)
+                    .hostDepCode(invalidToNull(sprvsnInstCd))
+                    .build();
+        }catch (NullPointerException e){
+            throw e;
         }
-
-        String[] dates = aplyYmd.split("\\\\N");
-        if (dates.length > 1 && !isEqualApplyDates(dates)) { // 서로 다른 신청 기간이 여러 개인 경우
-            repeatCode = RepeatCode.ALWAYS; // 상시 처리
-        }
-
-        LocalDate[] applyDates = parsingApplyYmd(dates[0]);
-        LocalDate applyStart = applyDates[0];
-        LocalDate applyDue = applyDates[1];
-
-        Earn earn = Earn.fromKey(plcyNo, earnCndSeCd);
-        Boolean isLimitedAge = sprtTrgtAgeLmtYn == null ? null : "N".equals(sprtTrgtAgeLmtYn);
-        Region region = findRegion();
-        LocalDate[] bizTerm = parsingBizTerm();
-        
-        int minAge = isLimitedAge != null && isLimitedAge && !sprtTrgtMinAge.isEmpty()
-                ? Integer.parseInt(sprtTrgtMinAge) : 0;
-        int maxAge = isLimitedAge != null && isLimitedAge && !sprtTrgtMaxAge.isEmpty()
-                ? Integer.parseInt(sprtTrgtMaxAge) : 100;
-        int maxEarn = earn.equals(Earn.ANNUL_INCOME) && !earnMaxAmt.isEmpty() ? Integer.parseInt(earnMaxAmt) : 0;
-        int minEarn = earn.equals(Earn.ANNUL_INCOME) && !earnMinAmt.isEmpty() ? Integer.parseInt(earnMinAmt) : 0;
-
-        return Policy.builder()
-                .policyNum(plcyNo)
-                .region(region)
-                .title(plcyNm)
-                .institutionType(InstitutionType.fromKey(plcyNo, pvsnInstGroupCd))
-                .isLimitedAge(isLimitedAge)
-                .minAge(minAge)
-                .maxAge(maxAge)
-                .repeatCode(repeatCode)
-                .applyTerm(aplyYmd)
-                .applyStart(applyStart)
-                .applyDue(applyDue)
-                .addition(invalidToNull(addAplyQlfcCndCn))
-                .etc(invalidToNull(etcMttrCn))
-                .applLimit(invalidToNull(ptcpPrpTrgtCn))
-                .applStep(invalidToNull(plcyAplyMthdCn))
-                .applUrl(invalidToNull(aplyUrlAddr))
-                .category(Category.fromKey(plcyNo, bscPlanPlcyWayNo))
-                .education(Education.findEducationList(plcyNo, schoolCd))
-                .employment(Employment.findEmploymentList(plcyNo, jobCd))
-                .hostDep(invalidToNull(sprvsnInstCdNm))
-                .refUrl1(invalidToNull(refUrlAddr1))
-                .refUrl2(invalidToNull(refUrlAddr2))
-                .evaluation(invalidToNull(srngMthdCn))
-                .introduction(invalidToNull(plcyExplnCn))
-                .operatingOrg(invalidToNull(operInstCdNm))
-                .specialization(Specialization.findSpecializationList(plcyNo, sbizCd))
-                .major(Major.findMajorList(plcyNo, plcyMajorCd))
-                .submitDoc(invalidToNull(sbmsnDcmntCn))
-                .supportDetail(invalidToNull(plcySprtCn))
-                .earn(earn)
-                .maxEarn(maxEarn)
-                .minEarn(minEarn)
-                .earnEtc(invalidToNull(earnEtcCn))
-                .marriage(Marriage.fromKey(plcyNo, mrgSttsCd))
-                .zipCd(invalidToNull(zipCd))
-                .bizStart(bizTerm[0])
-                .bizDue(bizTerm[1])
-                .department(department)
-                .hostDepCode(invalidToNull(sprvsnInstCd))
-                .build();
     }
 
     // 지역 코드 매핑
@@ -203,5 +209,16 @@ public record PolicyData(
             }
         }
         return value;
+    }
+
+    private int parseAge(Boolean isLimitedAge, String value, int defaultValue) {
+        return Boolean.TRUE.equals(isLimitedAge) && value != null && !value.isEmpty()
+                ? Integer.parseInt(value)
+                : defaultValue;
+    }
+
+    private int parseEarn(Earn earn, String value, int defaultValue) {
+        return earn.equals(Earn.ANNUL_INCOME) && value != null && !earnMaxAmt.isEmpty()
+                ? Integer.parseInt(value) : defaultValue;
     }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
+import java.util.Set;
 
 @Slf4j
 @Builder(toBuilder = true)
@@ -77,6 +78,7 @@ public record PolicyData(
     private static final int DEFAULT_MAX_AGE = 100;
     private static final int DEFAULT_MIN_EARN = 0;
     private static final int DEFAULT_MAX_EARN = 0;
+    private static final Set<String> INVALID_STRINGS = Set.of("null", "NULL", "-");
 
     public Policy toPolicy(Department department) {
         RepeatCode repeatCode = RepeatCode.fromKey(plcyNo, aplyPrdSeCd);
@@ -204,7 +206,7 @@ public record PolicyData(
     private String invalidToNull(String value){
         if (value != null) {
             String str = value.trim();
-            if((str.isBlank() || str.equals("null") || str.equals("NULL") || str.equals("-"))){
+            if((str.isBlank() || INVALID_STRINGS.contains(str))){
                 return null;
             }
         }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
@@ -92,9 +92,16 @@ public record PolicyData(
         LocalDate applyDue = applyDates[1];
 
         Earn earn = Earn.fromKey(plcyNo, earnCndSeCd);
-        boolean isLimitedAge = sprtTrgtAgeLmtYn.equals("N");
+        Boolean isLimitedAge = sprtTrgtAgeLmtYn == null ? null : "N".equals(sprtTrgtAgeLmtYn);
         Region region = findRegion();
         LocalDate[] bizTerm = parsingBizTerm();
+        
+        int minAge = isLimitedAge != null && isLimitedAge && !sprtTrgtMinAge.isEmpty()
+                ? Integer.parseInt(sprtTrgtMinAge) : 0;
+        int maxAge = isLimitedAge != null && isLimitedAge && !sprtTrgtMaxAge.isEmpty()
+                ? Integer.parseInt(sprtTrgtMaxAge) : 100;
+        int maxEarn = earn.equals(Earn.ANNUL_INCOME) && !earnMaxAmt.isEmpty() ? Integer.parseInt(earnMaxAmt) : 0;
+        int minEarn = earn.equals(Earn.ANNUL_INCOME) && !earnMinAmt.isEmpty() ? Integer.parseInt(earnMinAmt) : 0;
 
         return Policy.builder()
                 .policyNum(plcyNo)
@@ -102,40 +109,40 @@ public record PolicyData(
                 .title(plcyNm)
                 .institutionType(InstitutionType.fromKey(plcyNo, pvsnInstGroupCd))
                 .isLimitedAge(isLimitedAge)
-                .minAge(isLimitedAge && !sprtTrgtMinAge.isEmpty() ? Integer.parseInt(sprtTrgtMinAge) : 0)
-                .maxAge(isLimitedAge && !sprtTrgtMaxAge.isEmpty() ? Integer.parseInt(sprtTrgtMaxAge) : 0)
+                .minAge(minAge)
+                .maxAge(maxAge)
                 .repeatCode(repeatCode)
                 .applyTerm(aplyYmd)
                 .applyStart(applyStart)
                 .applyDue(applyDue)
-                .addition(addAplyQlfcCndCn)
-                .etc(etcMttrCn)
-                .applLimit(ptcpPrpTrgtCn)
-                .applStep(plcyAplyMthdCn)
-                .applUrl(aplyUrlAddr)
+                .addition(invalidToNull(addAplyQlfcCndCn))
+                .etc(invalidToNull(etcMttrCn))
+                .applLimit(invalidToNull(ptcpPrpTrgtCn))
+                .applStep(invalidToNull(plcyAplyMthdCn))
+                .applUrl(invalidToNull(aplyUrlAddr))
                 .category(Category.fromKey(plcyNo, bscPlanPlcyWayNo))
                 .education(Education.findEducationList(plcyNo, schoolCd))
                 .employment(Employment.findEmploymentList(plcyNo, jobCd))
-                .hostDep(sprvsnInstCdNm)
-                .refUrl1(refUrlAddr1)
-                .refUrl2(refUrlAddr2)
-                .evaluation(srngMthdCn)
-                .introduction(plcyExplnCn)
-                .operatingOrg(operInstCdNm)
+                .hostDep(invalidToNull(sprvsnInstCdNm))
+                .refUrl1(invalidToNull(refUrlAddr1))
+                .refUrl2(invalidToNull(refUrlAddr2))
+                .evaluation(invalidToNull(srngMthdCn))
+                .introduction(invalidToNull(plcyExplnCn))
+                .operatingOrg(invalidToNull(operInstCdNm))
                 .specialization(Specialization.findSpecializationList(plcyNo, sbizCd))
                 .major(Major.findMajorList(plcyNo, plcyMajorCd))
-                .submitDoc(sbmsnDcmntCn)
-                .supportDetail(plcySprtCn)
+                .submitDoc(invalidToNull(sbmsnDcmntCn))
+                .supportDetail(invalidToNull(plcySprtCn))
                 .earn(earn)
-                .maxEarn(earn.equals(Earn.ANNUL_INCOME) && !earnMaxAmt.isEmpty() ? Integer.parseInt(earnMaxAmt) : 0)
-                .minEarn(earn.equals(Earn.ANNUL_INCOME) && !earnMinAmt.isEmpty() ? Integer.parseInt(earnMinAmt) : 0)
-                .earnEtc(earnEtcCn)
+                .maxEarn(maxEarn)
+                .minEarn(minEarn)
+                .earnEtc(invalidToNull(earnEtcCn))
                 .marriage(Marriage.fromKey(plcyNo, mrgSttsCd))
-                .zipCd(zipCd)
+                .zipCd(invalidToNull(zipCd))
                 .bizStart(bizTerm[0])
                 .bizDue(bizTerm[1])
                 .department(department)
-                .hostDepCode(sprvsnInstCd)
+                .hostDepCode(invalidToNull(sprvsnInstCd))
                 .build();
     }
 
@@ -186,5 +193,15 @@ public record PolicyData(
             compare = date;
         }
         return true;
+    }
+
+    private String invalidToNull(String value){
+        if (value != null) {
+            String str = value.trim();
+            if((str.isBlank() || str.equals("null") || str.equals("NULL") || str.equals("-"))){
+                return null;
+            }
+        }
+        return value;
     }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/InstitutionType.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/InstitutionType.java
@@ -14,6 +14,8 @@ public enum InstitutionType {
     private final String key;
     // 담당 기관 타입 매핑
     public static InstitutionType fromKey(String policyNum, String key){
+        if(key == null) return InstitutionType.CENTER;
+
         return switch (key) {
             case "0054001" -> InstitutionType.CENTER;
             case "0054002" -> InstitutionType.LOCAL;

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/Policy.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/Policy.java
@@ -28,14 +28,14 @@ public class Policy extends BaseTimeEntity {
     private String policyNum; // 정책 번호
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "region", length = 20)
+    @Column(name = "region", length = 20, nullable = false)
     private Region region; // 지역
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "institution_type", length = 20)
+    @Column(name = "institution_type", length = 20, nullable = false)
     private InstitutionType institutionType; // 담당기관 구분(중앙부처, 지자체)
 
-    @Column(name = "title", length = 150)
+    @Column(name = "title", length = 150, nullable = false)
     private String title; // 정책명
 
     @Column(name = "introduction", columnDefinition = "TEXT")
@@ -48,7 +48,7 @@ public class Policy extends BaseTimeEntity {
     private String applyTerm; // 신청기간
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "repeat_code", length = 20)
+    @Column(name = "repeat_code", length = 20, nullable = false)
     private RepeatCode repeatCode; // 신청 기간 반복 코드
 
     @Column(name = "apply_start")
@@ -58,10 +58,10 @@ public class Policy extends BaseTimeEntity {
     private LocalDate applyDue; // 신청 마감일
 
     @Column(name = "min_age")
-    private Integer minAge; // 최소 연령
+    private int minAge; // 최소 연령
 
     @Column(name = "max_age")
-    private Integer maxAge; // 최대 연령
+    private int maxAge; // 최대 연령
 
     @Column(name = "addition", columnDefinition = "TEXT")
     private String addition; // 추가 사항
@@ -136,7 +136,7 @@ public class Policy extends BaseTimeEntity {
     private List<Education> education; // 학력 요건
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "marriage", length = 255)
+    @Column(name = "marriage", length = 255, nullable = false)
     private Marriage marriage; // 결혼 요건
 
     @ElementCollection

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/RepeatCode.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/RepeatCode.java
@@ -16,6 +16,8 @@ public enum RepeatCode {
     private final String name;
 
     public static RepeatCode fromKey(String policyNum, String key){
+        if(key == null) return RepeatCode.ALWAYS;
+
         return switch (key) {
             case "0057001" -> RepeatCode.PERIOD;
             case "0057002" -> RepeatCode.ALWAYS;

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Earn.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Earn.java
@@ -14,6 +14,8 @@ public enum Earn {
     private final String name;
 
     public static Earn fromKey(String policyId, String key){
+        if(key == null) return Earn.UNRESTRICTED;
+
         return switch (key) {
             case "0043001" -> Earn.UNRESTRICTED;
             case "0043002" -> Earn.ANNUL_INCOME;

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Marriage.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/condition/Marriage.java
@@ -14,6 +14,8 @@ public enum Marriage {
     private final String name;
 
     public static Marriage fromKey(String policyNum, String key) {
+        if (key == null) return Marriage.UNRESTRICTED;
+
         return switch(key){
                 case "0055001" -> Marriage.MARRIED;
                 case "0055002" -> Marriage.SINGLE;

--- a/src/test/java/com/server/youthtalktalk/repository/policy/PolicyQueryRepositoryTest.java
+++ b/src/test/java/com/server/youthtalktalk/repository/policy/PolicyQueryRepositoryTest.java
@@ -19,15 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static com.server.youthtalktalk.domain.policy.entity.InstitutionType.CENTER;
 
 import com.server.youthtalktalk.domain.policy.dto.SearchConditionDto;
-import com.server.youthtalktalk.domain.policy.entity.Category;
-import com.server.youthtalktalk.domain.policy.entity.InstitutionType;
-import com.server.youthtalktalk.domain.policy.entity.Policy;
-import com.server.youthtalktalk.domain.policy.entity.SortOption;
-import com.server.youthtalktalk.domain.policy.entity.condition.Education;
-import com.server.youthtalktalk.domain.policy.entity.condition.Employment;
-import com.server.youthtalktalk.domain.policy.entity.condition.Major;
-import com.server.youthtalktalk.domain.policy.entity.condition.Marriage;
-import com.server.youthtalktalk.domain.policy.entity.condition.Specialization;
+import com.server.youthtalktalk.domain.policy.entity.*;
+import com.server.youthtalktalk.domain.policy.entity.condition.*;
 import com.server.youthtalktalk.domain.policy.entity.region.PolicySubRegion;
 import com.server.youthtalktalk.domain.policy.entity.region.Region;
 import com.server.youthtalktalk.domain.policy.entity.region.SubRegion;
@@ -334,6 +327,7 @@ public class PolicyQueryRepositoryTest {
                     ))
                     .major(List.of(majors[i % majors.length], majors[(i + 2) % majors.length]))
                     .employment(List.of(employments[i % employments.length]))
+                    .repeatCode(RepeatCode.PERIOD)
                     .view(i)
                     .build();
 
@@ -370,7 +364,17 @@ public class PolicyQueryRepositoryTest {
     }
 
     private Policy savePolicy(String title, String policyNum, Long view) {
-        Policy policy = Policy.builder().title(title).policyNum(policyNum).view(view).build();
+        Policy policy = Policy.builder()
+                .title(title)
+                .policyNum(policyNum)
+                .view(view)
+                .institutionType(CENTER)
+                .repeatCode(RepeatCode.ALWAYS)
+                .earn(ANNUL_INCOME)
+                .marriage(Marriage.UNRESTRICTED)
+                .category(JOB)
+                .region(Region.ALL)
+                .build();
         return policyRepository.save(policy);
     }
 }


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #12 

### ⛳ 작업 분류
- [x] 필드 일부 nullable = false 처리, 기본값 설정
- [x] "-", 공백을 포함한 빈 값 null 처리 

### 🔨 작업 상세 내용
1. **region, institutionType, title, repeatCode, marriage, earn**은 nullable = false처리
- 기존에 기본값 설정이 돼있는 필드들은 nullable = false 처리
- title은 null이 되면 안되는 필드라고 생각해서 처리했습니다.
```sql 
ALTER TABLE policy MODIFY COLUMN region ENUM( 'SEOUL', 'BUSAN', 'DAEGU', 'INCHEON', 'GWANGJU', 'DAEJEON', 'ULSAN', 'GYEONGGI', 'GANGWON', 'CHUNGBUK', 'CHUNGNAM', 'JEONBUK', 'JEONNAM', 'GYEONGBUK', 'GYEONGNAM', 'JEJU', 'SEJONG', 'ALL' ) NOT NULL; 
ALTER TABLE policy MODIFY COLUMN institution_type ENUM('CENTER', 'LOCAL') NOT NULL; 
ALTER TABLE policy MODIFY COLUMN title VARCHAR(150) NOT NULL; 
ALTER TABLE policy MODIFY COLUMN repeat_code ENUM('ALWAYS', 'PERIOD', 'FINISHED') NOT NULL; 
ALTER TABLE policy MODIFY COLUMN marriage ENUM('MARRIED', 'SINGLE', 'UNRESTRICTED') NOT NULL; 
ALTER TABLE policy MODIFY COLUMN earn ENUM('UNRESTRICTED', 'ANNUL_INCOME', 'OTHER') NOT NULL; 
```

nullable관련 문서 정리했습니다.
https://www.notion.so/Policy-nullable-1d3fe759e3f580aca8dee259aa8d4cb3?pvs=4

2. 공백을 포함한 빈 값, "-", "NULL", "null"인 경우 null 처리했습니다.
3. 리뷰 반영 : 중복 코드는 메서드 추출, 매직 넘버는 상수 처리, 유효하지 않은 값은 Set으로 상수 처리하여 contains로 비교
4. PolicyQueryRepositoryTest 수정

### 📍 이슈
- null처리가 안되는 정책들이 40개정도 존재합니다. 디버깅해봤는데 해당 정책이 데이터 패치 시 api로 불러온 데이터들 중에 없는거 같더라구요. 그래서 수정되지 않습니다. 지금 확인해보니 온통청년 측 데이터가 40개 정도 더 적어요. 그쪽에서 삭제된 정책이 있는거 같습니다. 홈페이지에서 개별 정책 id로 검색하면 뜨는데, 온통청년 목록 조회에서는 안보이네요. 마감된 정책이라서 전체 목록에서는 삭제한게 아닐까 싶습니다.

의견 반영했습니다!
```sql
UPDATE policy SET introduction = NULL WHERE TRIM(introduction) IN ('', '-', 'null', 'NULL');
UPDATE policy SET support_detail = NULL WHERE TRIM(support_detail) IN ('', '-', 'null', 'NULL');
UPDATE policy SET apply_term = NULL WHERE TRIM(apply_term) IN ('', '-', 'null', 'NULL');
UPDATE policy SET apply_start = NULL WHERE TRIM(apply_start) IN ('', '-', 'null', 'NULL');
UPDATE policy SET apply_due = NULL WHERE TRIM(apply_due) IN ('', '-', 'null', 'NULL');
UPDATE policy SET is_limited_age = NULL WHERE TRIM(is_limited_age) IN ('', '-', 'null', 'NULL');
UPDATE policy SET addition = NULL WHERE TRIM(addition) IN ('', '-', 'null', 'NULL');
UPDATE policy SET appl_limit = NULL WHERE TRIM(appl_limit) IN ('', '-', 'null', 'NULL');
UPDATE policy SET appl_step = NULL WHERE TRIM(appl_step) IN ('', '-', 'null', 'NULL');
UPDATE policy SET submit_doc = NULL WHERE TRIM(submit_doc) IN ('', '-', 'null', 'NULL');
UPDATE policy SET evaluation = NULL WHERE TRIM(evaluation) IN ('', '-', 'null', 'NULL');
UPDATE policy SET appl_url = NULL WHERE TRIM(appl_url) IN ('', '-', 'null', 'NULL');
UPDATE policy SET ref_url1 = NULL WHERE TRIM(ref_url1) IN ('', '-', 'null', 'NULL');
UPDATE policy SET ref_url2 = NULL WHERE TRIM(ref_url2) IN ('', '-', 'null', 'NULL');
UPDATE policy SET host_dep = NULL WHERE TRIM(host_dep) IN ('', '-', 'null', 'NULL');
UPDATE policy SET operating_org = NULL WHERE TRIM(operating_org) IN ('', '-', 'null', 'NULL');
UPDATE policy SET etc = NULL WHERE TRIM(etc) IN ('', '-', 'null', 'NULL');
UPDATE policy SET earn_etc = NULL WHERE TRIM(earn_etc) IN ('', '-', 'null', 'NULL');
UPDATE policy SET zip_cd = NULL WHERE TRIM(zip_cd) IN ('', '-', 'null', 'NULL');
UPDATE policy SET biz_start = NULL WHERE TRIM(biz_start) IN ('', '-', 'null', 'NULL');
UPDATE policy SET biz_due = NULL WHERE TRIM(biz_due) IN ('', '-', 'null', 'NULL');
UPDATE policy SET host_dep_code = NULL WHERE TRIM(host_dep_code) IN ('', '-', 'null', 'NULL');
```

- 예전에도 언급이 됐던 이슈인데, **온통청년 측에서 데이터를 삭제해도 저희쪽 DB에는 정책이 남아있게 됩니다**. 근데 저희가 policyId를 따로 사용 중이라 데이터 패치 시 **전체 정책 데이터를 삭제하고 패치하는 작업은 불가능합니다**. 그래서 제가 생각한 방법은 다음과 같습니다.

1. null처리가 되지 않은 정책들만 따로 쿼리로 빈값이나, "-"을 null로 변환해줍니다.(40개 예상)
2. 데이터 패치 시 온통청년에서 불러온 데이터들과, DB에 있는 데이터를 비교해서 존재하지 않는 정책들은 삭제하기. (일일이 비교하면 O(n^2)이라 굉장히 비효율적일거 같습니다. HashMap, HashSet을 사용하면 O(n)일거 같네요. 다른 알고리즘을 사용할 수도 있고, 방법은 많을 거 같아요.)