### PR TITLE
[FIX] 상시일 경우 applDue, applStart null 처리

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
@@ -84,19 +84,20 @@ public record PolicyData(
         RepeatCode repeatCode = RepeatCode.fromKey(plcyNo, aplyPrdSeCd);
 
         try {
-            // 신청 기간 파싱(상시인 경우 x)
-            if (aplyYmd.length() > 20) {
-                log.info("aplyYmd policyId = {}", plcyNo);
-            }
-
             String[] dates = aplyYmd.split("\\\\N");
             if (dates.length > 1 && !isEqualApplyDates(dates)) { // 서로 다른 신청 기간이 여러 개인 경우
                 repeatCode = RepeatCode.ALWAYS; // 상시 처리
             }
 
-            LocalDate[] applyDates = parsingApplyYmd(dates[0]);
-            LocalDate applyStart = applyDates[0];
-            LocalDate applyDue = applyDates[1];
+            LocalDate applyStart = null;
+            LocalDate applyDue = null;
+
+            // 반복코드가 상시인 경우 신청기간 null 처리
+            if(!repeatCode.equals(RepeatCode.ALWAYS)){
+                LocalDate[] applyDates = parsingApplyYmd(dates[0]);
+                applyStart = applyDates[0];
+                applyDue = applyDates[1];
+            }
 
             Earn earn = Earn.fromKey(plcyNo, earnCndSeCd);
             Boolean isLimitedAge = sprtTrgtAgeLmtYn == null ? null : "N".equals(sprtTrgtAgeLmtYn);

--- a/src/test/java/com/server/youthtalktalk/service/policy/PolicyDataServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/policy/PolicyDataServiceTest.java
@@ -3,6 +3,7 @@ package com.server.youthtalktalk.service.policy;
 import com.server.youthtalktalk.domain.policy.dto.data.PolicyData;
 import com.server.youthtalktalk.domain.policy.entity.Department;
 import com.server.youthtalktalk.domain.policy.entity.Policy;
+import com.server.youthtalktalk.domain.policy.entity.RepeatCode;
 import com.server.youthtalktalk.domain.policy.repository.DepartmentRepository;
 import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
 import com.server.youthtalktalk.domain.policy.service.data.PolicyDataServiceImpl;
@@ -105,6 +106,26 @@ public class PolicyDataServiceTest {
         String[] dates = applyDate.split("\\\\N");
         assertThat(dates[0]).isEqualTo("20250401 ~ 20250430");
     }
+
+    @DisplayName("반복코드 상시일 경우 신청 기간 null 처리")
+    @Test
+    void successApplyDateNullIfRepeatCodeIsAlways(){
+        String aplyPrdSeCd = RepeatCode.ALWAYS.getKey();
+        policyData.toBuilder().aplyPrdSeCd(aplyPrdSeCd).build();
+
+        Department defaultDepartment = Department.builder()
+                .departmentId(1L)
+                .code("0000000")
+                .name("기본")
+                .image_url("")
+                .build();
+        Policy policy = policyData.toPolicy(defaultDepartment);
+
+        assertThat(policy.getApplyStart()).isNull();
+        assertThat(policy.getApplyDue()).isNull();
+        assertThat(policy.getApplyTerm()).isNotNull();
+    }
+
 
     @DisplayName("예외 감지로 인한 정책 데이터 엔티티 변환 실패, 다른 데이터 이어서 변환 성공")
     @Test


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #12 

### ⛳ 작업 분류
- [x] PolicyData : 정책 패치 시 상시인 정책 신청기간 null 처리

### 🔨 작업 상세 내용
1. `Repeatcode.ALWAYS`인 경우 따로 parsing작업을 거치지 않고 null 처리하였습니다.
2. PolicyDataServiceTest에 테스트 메서드 추가하였습니다.