### PR TITLE
[FIX] 댓글 조회 시 차단한 유저의 댓글 제외하도록 로직 추가

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyRepository.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 @Repository
 public interface PolicyRepository extends JpaRepository<Policy,String>, PolicyQueryRepository {
 
-
     /**
      * top5 정책 조회 (조회수순)
      */
@@ -35,7 +34,6 @@ public interface PolicyRepository extends JpaRepository<Policy,String>, PolicyQu
      */
     @Query("SELECT p FROM Policy p WHERE (p.region = :region OR p.region = 'ALL') AND  (REPLACE(p.title, ' ', '') LIKE CONCAT('%', :title, '%')) ORDER BY p.policyNum DESC")
     Page<Policy> findByRegionAndTitle(@Param("region") Region region, @Param("title") String title, Pageable pageable);
-
 
     /**
      * 특정 정책 조회
@@ -56,4 +54,9 @@ public interface PolicyRepository extends JpaRepository<Policy,String>, PolicyQu
     Page<Policy> findTop5OrderByDeadlineAsc(Member member, Pageable pageable);
 
     Optional<Policy> findByPolicyNum(String policyNum);
+
+    /**
+     * policyId로 정책 존재 여부 검사
+     */
+    boolean existsByPolicyId(Long policyId);
 }

--- a/src/main/java/com/server/youthtalktalk/domain/post/repostiory/PostRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/repostiory/PostRepository.java
@@ -1,17 +1,11 @@
 package com.server.youthtalktalk.domain.post.repostiory;
 
-import com.server.youthtalktalk.domain.member.entity.Member;
-import com.server.youthtalktalk.domain.policy.entity.Category;
 import com.server.youthtalktalk.domain.post.entity.Post;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import lombok.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+    boolean existsById(@NonNull Long id);
 }


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #29 

### ⛳ 작업 분류
- [x] `PostRepository.existsById` 및 `PolicyRepository.existsByPolicyId` 구현
- [x] `policyId` 또는 `postId`로 전체 댓글 조회하는 메서드에서 예외 검증 코드 리팩토링 
- [x] id로 조회한 전체 댓글에서 차단한 유저가 작성한 댓글 제외하도록 로직 추가
- [x] 테스트 코드 구현

### 🔨 작업 상세 내용
1. 특정 게시글(또는 정책)의 전체 댓글을 조회할 때, ID의 유효성을 검증하는 방식을 개선했습니다. 조회 대상이 되는 `policyId`나 `postId`가 DB에 존재하는지만 확인하면 되므로, 기존의 `findById` 대신 `existsBy`를 사용해 불필요한 엔티티 조회를 줄였습니다.
2. 전체 댓글을 가져온 후에 dto로 변환하는 메서드에서 차단 유저의 댓글은 제외하는 로직을 추가했습니다. 현재 코드에는 dto 변환 메서드에 비즈니스 로직이 섞여있어서 책임 분리가 필요해보이는데, 1차 개편을 위한 빠른 작업을 위해 이 부분은 개편 이후에 리팩토링 진행하겠습니다.
3. `CommentServiceTest`에 차단한 사용자의 댓글이 제외되는 로직에 대한 테스트 코드를 추가했습니다.

### 📍 참고 사항
- `CommentSerivceTest`에서 중복되는 코드가 존재하고, 예외 케이스 검증이 부족해보입니다. 이 부분도 1차 개편 이후에 리팩토링하겠습니다.
- merge 후에 dev 서버 배포 및 api 명세서 업데이트 예정입니다.
