### PR TITLE
[FIX] 닉네임 조건 변경

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/member/controller/MemberController.java
+++ b/src/main/java/com/server/youthtalktalk/domain/member/controller/MemberController.java
@@ -21,6 +21,8 @@ import static com.server.youthtalktalk.global.response.BaseResponseCode.*;
 public class MemberController {
 
     private static final int MAX_PROFILE_SIZE = 5 * 1024 * 1024; // 5MB
+    public static final String NICKNAME_REGEX = "^[a-zA-Z가-힣]{1,8}$"; // 닉네임 조건식
+
     private final MemberService memberService;
     private final ImageService imageService;
 

--- a/src/main/java/com/server/youthtalktalk/domain/member/controller/MemberController.java
+++ b/src/main/java/com/server/youthtalktalk/domain/member/controller/MemberController.java
@@ -21,7 +21,7 @@ import static com.server.youthtalktalk.global.response.BaseResponseCode.*;
 public class MemberController {
 
     private static final int MAX_PROFILE_SIZE = 5 * 1024 * 1024; // 5MB
-    public static final String NICKNAME_REGEX = "^[a-zA-Z가-힣]{1,8}$"; // 닉네임 조건식
+    public static final String NICKNAME_REGEX = "^[a-zA-Z가-힣0-9]+$"; // 닉네임 조건
 
     private final MemberService memberService;
     private final ImageService imageService;

--- a/src/main/java/com/server/youthtalktalk/domain/member/dto/MemberUpdateDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/member/dto/MemberUpdateDto.java
@@ -6,10 +6,10 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record MemberUpdateDto(
-        @Size(max = 8, message = "닉네임 길이는 8자 이하입니다.")
+        @Size(max = 8, message = "닉네임 길이는 1자 이상 8자 이하여야 합니다.")
         @Pattern(
                 regexp = NICKNAME_REGEX,
-                message = "닉네임은 한글과 영어로 1자 이상 8자 이하이며, 공백과 특수문자는 사용할 수 없습니다."
+                message = "닉네임은 한글과 영어(대소문자) 및 숫자만 가능하며, 공백과 특수문자는 사용할 수 없습니다."
         )
         String nickname,
         @Pattern(regexp = "서울|부산|대구|인천|광주|대전|울산|경기|강원|충북|충남|전북|전남|경북|경남|제주|세종",

--- a/src/main/java/com/server/youthtalktalk/domain/member/dto/MemberUpdateDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/member/dto/MemberUpdateDto.java
@@ -1,10 +1,16 @@
 package com.server.youthtalktalk.domain.member.dto;
 
+import static com.server.youthtalktalk.domain.member.controller.MemberController.NICKNAME_REGEX;
+
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record MemberUpdateDto(
         @Size(max = 8, message = "닉네임 길이는 8자 이하입니다.")
+        @Pattern(
+                regexp = NICKNAME_REGEX,
+                message = "닉네임은 한글과 영어로 1자 이상 8자 이하이며, 공백과 특수문자는 사용할 수 없습니다."
+        )
         String nickname,
         @Pattern(regexp = "서울|부산|대구|인천|광주|대전|울산|경기|강원|충북|충남|전북|전남|경북|경남|제주|세종",
                  message = "지역이 유효하지 않습니다.")

--- a/src/main/java/com/server/youthtalktalk/domain/member/dto/SignUpRequestDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/member/dto/SignUpRequestDto.java
@@ -1,8 +1,9 @@
 package com.server.youthtalktalk.domain.member.dto;
 
+import static com.server.youthtalktalk.domain.member.controller.MemberController.NICKNAME_REGEX;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,7 +18,10 @@ public class SignUpRequestDto {
     private String socialType;
 
     @NotBlank(message = "닉네임은 필수값입니다.")
-    @Size(max = 8, message = "닉네임 길이는 8자 이하입니다.")
+    @Pattern(
+            regexp = NICKNAME_REGEX,
+            message = "닉네임은 한글과 영어로 1자 이상 8자 이하이며, 공백과 특수문자는 사용할 수 없습니다."
+    )
     private String nickname;
 
     @NotBlank(message = "지역은 필수값입니다.")

--- a/src/main/java/com/server/youthtalktalk/domain/member/dto/SignUpRequestDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/member/dto/SignUpRequestDto.java
@@ -4,6 +4,7 @@ import static com.server.youthtalktalk.domain.member.controller.MemberController
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -18,9 +19,10 @@ public class SignUpRequestDto {
     private String socialType;
 
     @NotBlank(message = "닉네임은 필수값입니다.")
+    @Size(max = 8, message = "닉네임 길이는 1자 이상 8자 이하여야 합니다.")
     @Pattern(
             regexp = NICKNAME_REGEX,
-            message = "닉네임은 한글과 영어로 1자 이상 8자 이하이며, 공백과 특수문자는 사용할 수 없습니다."
+            message = "닉네임은 한글과 영어(대소문자) 및 숫자만 가능하며, 공백과 특수문자는 사용할 수 없습니다."
     )
     private String nickname;
 

--- a/src/main/java/com/server/youthtalktalk/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/member/service/MemberServiceImpl.java
@@ -44,7 +44,6 @@ public class MemberServiceImpl implements MemberService {
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
     private final BlockRepository blockRepository;
-
     private final JwtService jwtService;
     private final HttpServletResponse httpServletResponse;
     private final AppleAuthUtil appleAuthUtil;

--- a/src/test/java/com/server/youthtalktalk/service/member/MemberServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/member/MemberServiceTest.java
@@ -22,6 +22,7 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -109,7 +110,8 @@ class MemberServiceTest {
     }
 
     @Test
-    public void 회원가입_실패_Size_검증_오류() {
+    @DisplayName("회원가입 실패_닉네임 길이 제한 초과")
+    public void testSignUp1() {
         // given
         SignUpRequestDto signUpRequestDto1 = SignUpRequestDto.builder()
                 .socialId("11111").socialType("kakao").nickname("여덟글자보다긴닉네임").region("부산").build();
@@ -120,24 +122,30 @@ class MemberServiceTest {
         // then
         assertFalse(violations1.isEmpty());
         assertThat(violations1.size()).isEqualTo(1);
-        assertThat(violations1.iterator().next().getMessage()).isEqualTo("닉네임 길이는 8자 이하입니다.");
-
+        assertThat(violations1.iterator().next().getMessage()).isEqualTo("닉네임 길이는 1자 이상 8자 이하여야 합니다.");
     }
 
     @Test
-    public void 회원가입_실패_Pattern_검증_오류() {
+    @DisplayName("회원가입 실패_닉네임에 허용되지 않은 글자 포함")
+    public void testSignUp2() {
         // given
         SignUpRequestDto signUpRequestDto1 = SignUpRequestDto.builder()
-                .socialId("11111").socialType("kakao").nickname("member1").region("지역").build();
+                .socialId("11111").socialType("kakao").nickname("member1@").region("서울").build(); // 닉네임에 특수문자 포함
+        SignUpRequestDto signUpRequestDto2 = SignUpRequestDto.builder()
+                .socialId("22222").socialType("kakao").nickname("member2 ").region("서울").build(); // 닉네임에 공백 포함
 
         // when
         Set<ConstraintViolation<SignUpRequestDto>> violations1 = validator.validate(signUpRequestDto1);
+        Set<ConstraintViolation<SignUpRequestDto>> violations2 = validator.validate(signUpRequestDto2);
 
         // then
         assertFalse(violations1.isEmpty());
         assertThat(violations1.size()).isEqualTo(1);
-        assertThat(violations1.iterator().next().getMessage()).isEqualTo("지역이 유효하지 않습니다.");
+        assertThat(violations1.iterator().next().getMessage()).isEqualTo("닉네임은 한글과 영어(대소문자) 및 숫자만 가능하며, 공백과 특수문자는 사용할 수 없습니다.");
 
+        assertFalse(violations2.isEmpty());
+        assertThat(violations2.size()).isEqualTo(1);
+        assertThat(violations2.iterator().next().getMessage()).isEqualTo("닉네임은 한글과 영어(대소문자) 및 숫자만 가능하며, 공백과 특수문자는 사용할 수 없습니다.");
     }
 
     @Test


### PR DESCRIPTION

### ⛳ 작업 분류
- [x] 회원가입과 회원정보 수정 API의 요청 DTO에서 검증 조건 수정
- [x] `MemberServiceTest` 수정

### 🔨 작업 상세 내용
1. `MemberController`에 닉네임 정규식 상수 처리 및 dto 검증 로직 추가
닉네임의 허용가능한 문자 검증은 정규식을 사용해서 검증하도록 구현했습니다. 정규식은 회원가입 요청 dto와 회원정보 수정 요청 dto에서 모두 사용되므로, 상수 처리하여 재사용했습니다.
2. 길이 제한과 허용 가능한 문자 조건에 따라 각각 다른 예외 메시지가 반환되도록 분리했습니다.
3. 기존 `MemberServiceTest` 코드에서 닉네임 제한 조건과 관련된 테스트 케이스를 수정했습니다.

### 📍 참고 사항
- 검증 로직의 위치에 대한 고민이 계속 있었는데, 우선은 dto 단에서 스프링의 Validation을 사용하도록 구현했습니다. 리팩토링 시, 이 부분도 논의해보면 좋을 것 같습니다.
