### PR TITLE
[FIX] 정책 검색 시 필요한 최소/최대 소득값 변경

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
@@ -49,7 +49,7 @@ public class PolicyServiceImpl implements PolicyService {
     public static final int MIN_AGE_INPUT = 8;
     public static final int MAX_AGE_INPUT = 100;
     public static final int MIN_EARN_INPUT = 0;
-    public static final int MAX_EARN_INPUT = 2_000_000_000;
+    public static final int MAX_EARN_INPUT = 50_000_000;
     public static final String APPLY_DUE_FORMAT = "yyyy-MM-dd";
 
     private final PolicyRepository policyRepository;


### PR DESCRIPTION
### ⛳ 작업 분류
- [x] 정책 검색 조건인 소득의 최소, 최대값 변경

### 🔨 작업 상세 내용
1. 정책 검색 조건이 연소득인 경우 유효하지 않은 숫자값을 검증하기 위해 최소/최대값을 설정했었는데, 디자인 시안에 나온 대로 값을 최대값을 5천만원으로 변경했습니다. 

### 📍 참고 사항
- 리터럴 값만 변경했기 때문에 바로 머지하겠습니다.
