### PR TITLE
[FEAT] 댓글 신고 API 구현

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/comment/entity/Comment.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/entity/Comment.java
@@ -3,6 +3,8 @@ package com.server.youthtalktalk.domain.comment.entity;
 import com.server.youthtalktalk.domain.BaseTimeEntity;
 import com.server.youthtalktalk.domain.likes.entity.Likes;
 import com.server.youthtalktalk.domain.member.entity.Member;
+import com.server.youthtalktalk.domain.report.entity.CommentReport;
+import com.server.youthtalktalk.domain.report.entity.PostReport;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -32,6 +34,10 @@ public abstract class Comment extends BaseTimeEntity {
     @Builder.Default
     @OneToMany(mappedBy = "comment")
     private List<Likes> commentLikes = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL)
+    private List<CommentReport> commentReports = new ArrayList<>();
 
     /* 연관관계 메서드 */
     public void setWriter(Member member) {

--- a/src/main/java/com/server/youthtalktalk/domain/member/entity/Member.java
+++ b/src/main/java/com/server/youthtalktalk/domain/member/entity/Member.java
@@ -61,6 +61,7 @@ public class Member extends BaseTimeEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Block> blocks = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "reporter", cascade = CascadeType.ALL)
     private List<Report> reports = new ArrayList<>();
 

--- a/src/main/java/com/server/youthtalktalk/domain/report/controller/ReportController.java
+++ b/src/main/java/com/server/youthtalktalk/domain/report/controller/ReportController.java
@@ -32,9 +32,9 @@ public class ReportController {
     }
 
     @PostMapping("/comments/{id}")
-    public BaseResponse<String> reportComment(@PathVariable Long commentId){
+    public BaseResponse<String> reportComment(@PathVariable Long id){
         Member reporter = memberService.getCurrentMember();
-        Comment comment = commentRepository.findById(commentId).orElseThrow(CommentNotFoundException::new);
+        Comment comment = commentRepository.findById(id).orElseThrow(CommentNotFoundException::new);
         reportService.reportComment(comment, reporter);
         return new BaseResponse<>(BaseResponseCode.SUCCESS);
     }

--- a/src/main/java/com/server/youthtalktalk/domain/report/controller/ReportController.java
+++ b/src/main/java/com/server/youthtalktalk/domain/report/controller/ReportController.java
@@ -1,9 +1,14 @@
 package com.server.youthtalktalk.domain.report.controller;
 
+import com.server.youthtalktalk.domain.comment.entity.Comment;
+import com.server.youthtalktalk.domain.comment.repository.CommentRepository;
+import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.member.service.MemberService;
+import com.server.youthtalktalk.domain.report.repository.ReportRepository;
 import com.server.youthtalktalk.domain.report.service.ReportService;
 import com.server.youthtalktalk.global.response.BaseResponse;
 import com.server.youthtalktalk.global.response.BaseResponseCode;
+import com.server.youthtalktalk.global.response.exception.comment.CommentNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,12 +20,23 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/report")
 @RequiredArgsConstructor
 public class ReportController {
+
     private final ReportService reportService;
     private final MemberService memberService;
+    private final CommentRepository commentRepository;
 
     @PostMapping("/post/{id}")
     public BaseResponse<String> reportPost(@PathVariable Long id){
         reportService.reportPost(id, memberService.getCurrentMember());
         return new BaseResponse<>(BaseResponseCode.SUCCESS);
     }
+
+    @PostMapping("/comments/{id}")
+    public BaseResponse<String> reportComment(@PathVariable Long commentId){
+        Member reporter = memberService.getCurrentMember();
+        Comment comment = commentRepository.findById(commentId).orElseThrow(CommentNotFoundException::new);
+        reportService.reportComment(comment, reporter);
+        return new BaseResponse<>(BaseResponseCode.SUCCESS);
+    }
+
 }

--- a/src/main/java/com/server/youthtalktalk/domain/report/entity/CommentReport.java
+++ b/src/main/java/com/server/youthtalktalk/domain/report/entity/CommentReport.java
@@ -1,0 +1,34 @@
+package com.server.youthtalktalk.domain.report.entity;
+
+import com.server.youthtalktalk.domain.comment.entity.Comment;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+@DiscriminatorValue("comment")
+public class CommentReport extends Report {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    /* 연관관계 메서드 */
+    public void setComment(Comment comment) {
+        this.comment = comment;
+        if (comment != null) {
+            comment.getCommentReports().add(this);
+        }
+    }
+}

--- a/src/main/java/com/server/youthtalktalk/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/report/repository/ReportRepository.java
@@ -12,4 +12,7 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
 
     @Query("SELECT COUNT(pr) > 0 FROM PostReport pr WHERE pr.post = :post AND pr.reporter = :reporter")
     boolean existsByPostAndReporter(Post post, Member reporter);
+
+    @Query("SELECT COUNT(cr) > 0 FROM CommentReport cr WHERE cr.comment.id = :commentId AND cr.reporter.id = :reporterId")
+    boolean existsByComment_IdAndReporter_Id(Long commentId, Long reporterId);
 }

--- a/src/main/java/com/server/youthtalktalk/domain/report/service/ReportService.java
+++ b/src/main/java/com/server/youthtalktalk/domain/report/service/ReportService.java
@@ -1,8 +1,10 @@
 package com.server.youthtalktalk.domain.report.service;
 
+import com.server.youthtalktalk.domain.comment.entity.Comment;
 import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.report.entity.Report;
 
 public interface ReportService {
     Report reportPost(Long postId, Member reporter);
+    Report reportComment(Comment comment, Member reporter);
 }

--- a/src/main/java/com/server/youthtalktalk/global/response/BaseResponseCode.java
+++ b/src/main/java/com/server/youthtalktalk/global/response/BaseResponseCode.java
@@ -96,8 +96,8 @@ public enum BaseResponseCode {
     ANNOUNCEMENT_NOT_FOUND_EXCEPTION("A01","해당 공지사항을 찾을 수 없습니다.",HttpStatus.NOT_FOUND.value()),
 
     // Report
-    REPORT_ALREADY_EXISTENCE_EXCEPTION("R01","이미 신고한 게시글입니다.",HttpStatus.CONFLICT.value()),
-    SELF_REPORT_NOT_ALLOWED_EXCEPTION("R02", "본인의 게시글은 신고할 수 없습니다.", HttpStatus.BAD_REQUEST.value());
+    REPORT_ALREADY_EXISTENCE_EXCEPTION("R01","이미 신고한 게시글(또는 댓글)입니다.",HttpStatus.CONFLICT.value()),
+    SELF_REPORT_NOT_ALLOWED_EXCEPTION("R02", "본인의 게시글(또는 댓글)은 신고할 수 없습니다.", HttpStatus.BAD_REQUEST.value());
 
     private final String code;
     private final String message;


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #29 

### ⛳ 작업 분류
- [x] 댓글 신고 엔티티 추가
- [x] 게시글 신고 로직과 동일하게 댓글 신고 API 구현
- [x] 댓글 신고 관련 테스트 코드 구현

### 🔨 작업 상세 내용
1. Report를 상속 받는 CommentReport를 추가했습니다.
2. 기존 게시글 신고 로직과 동일하게 댓글 신고 API를 위한 컨트롤러, 서비스, 레포지토리 코드를 구현했습니다.
3. 예외 케이스는 게시글 신고와 동일합니다. (자신이 작성한 댓글 신고, 이미 신고한 댓글을 다시 신고) 따라서 예외 응답에 사용되는 BaseResponseCode의 문구를 공통으로 사용할 수 있게 수정했습니다.

### 📍 참고 사항
- 배포 후 API 명세서 업데이트하겠습니다.
