### PR TITLE
[FEAT] 앱 실시간 내부 알림 기능 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,6 @@ dependencies {
 
 	implementation 'com.h2database:h2' // H2 데이터베이스 의존성 추가 (테스트용)
     implementation 'com.auth0:java-jwt:4.4.0' // jwt 설정
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client' // oauth2 client
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE' // s3
 
 	/* mysql 데이터베이스 설정 */
@@ -84,6 +83,9 @@ dependencies {
 	testImplementation 'org.mockito:mockito-core:4.8.0'
 	testImplementation 'org.mockito:mockito-inline:3.12.4'
 	testRuntimeOnly 'com.h2database:h2'
+	// Jackson for JSON processing
+	implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.16.1'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
 	// JUnit 5 (JUnit Jupiter) 의존성 명시적 선언
 //	testImplementation 'org.junit.jupiter:junit-jupiter-api'
@@ -104,4 +106,14 @@ tasks.register('copyYamlFiles', Copy) {
 
 processResources {
 	dependsOn tasks.named('copyYamlFiles')
+}
+
+tasks.withType(JavaCompile) {
+	options.encoding = 'UTF-8'
+}
+
+tasks.withType(Copy) {
+	filesMatching('**/*.properties') {
+		filter { line -> new String(line.getBytes('UTF-8'), 'UTF-8') }
+	}
 }

--- a/src/main/java/com/server/youthtalktalk/domain/member/entity/Member.java
+++ b/src/main/java/com/server/youthtalktalk/domain/member/entity/Member.java
@@ -3,6 +3,7 @@ package com.server.youthtalktalk.domain.member.entity;
 import com.server.youthtalktalk.domain.BaseTimeEntity;
 import com.server.youthtalktalk.domain.image.entity.ProfileImage;
 import com.server.youthtalktalk.domain.likes.entity.Likes;
+import com.server.youthtalktalk.domain.notification.entity.Notification;
 import com.server.youthtalktalk.domain.report.entity.Report;
 import com.server.youthtalktalk.domain.scrap.entity.Scrap;
 import com.server.youthtalktalk.domain.comment.entity.Comment;
@@ -63,6 +64,9 @@ public class Member extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "reporter", cascade = CascadeType.ALL)
     private List<Report> reports = new ArrayList<>();
+
+    @OneToMany(mappedBy = "receiver", cascade = CascadeType.ALL)
+    private List<Notification> notifications = new ArrayList<>();
 
     @JoinColumn(name = "img_id")
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)

--- a/src/main/java/com/server/youthtalktalk/domain/notification/api/NotificationController.java
+++ b/src/main/java/com/server/youthtalktalk/domain/notification/api/NotificationController.java
@@ -1,0 +1,65 @@
+package com.server.youthtalktalk.domain.notification.api;
+
+import com.server.youthtalktalk.domain.member.entity.Member;
+import com.server.youthtalktalk.domain.member.service.MemberService;
+import com.server.youthtalktalk.domain.notification.dto.NotificationListRepDto;
+import com.server.youthtalktalk.domain.notification.entity.NotificationType;
+import com.server.youthtalktalk.domain.notification.service.NotificationService;
+import com.server.youthtalktalk.domain.notification.service.SSEService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/notifications")
+public class NotificationController {
+    private final SSEService sseService;
+    private final ApplicationEventPublisher applicationEventPublisher;
+    private final NotificationService notificationService;
+    private final MemberService memberService;
+
+    // Last-Event-ID는 sse 연결이 끊어졌을 때 클라이언트가 받은 마지막 메세지. 항상 존재 x
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<SseEmitter> subscribe(@RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
+        return ResponseEntity.ok(sseService.subscribe(memberService.getCurrentMember(), lastEventId));
+    }
+
+    /**
+     * 알림 조회
+     * type : POST, POLICY
+     */
+    @GetMapping("")
+    public ResponseEntity<NotificationListRepDto> getAllPostNotificationInfo(@RequestParam NotificationType type, @PageableDefault(size = 10) Pageable pageable) {
+        Member member = memberService.getCurrentMember();
+        NotificationListRepDto notificationListResponse = notificationService.getAllNotificationsByType(member, type, pageable);
+        return ResponseEntity.ok().body(notificationListResponse);
+    }
+
+    /**
+     * 알림 확인
+     */
+    @PatchMapping("/{id}")
+    public ResponseEntity<String> checkNotification(@PathVariable("id") Long id){
+        notificationService.checkNotification(id);
+        return ResponseEntity.ok().body("Checking Successful");
+    }
+
+    /**
+     * 알림 삭제
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteNotification(@PathVariable("id") Long id){
+        notificationService.deleteNotification(id);
+        return ResponseEntity.ok().body("Delete Successful");
+    }
+
+    @GetMapping("/test")
+    public void test() {
+    }
+}

--- a/src/main/java/com/server/youthtalktalk/domain/notification/dto/NotificationListRepDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/notification/dto/NotificationListRepDto.java
@@ -1,0 +1,13 @@
+package com.server.youthtalktalk.domain.notification.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record NotificationListRepDto(
+        int page,
+        Long total,
+        List<NotificationRepDto> notifications
+) {
+}

--- a/src/main/java/com/server/youthtalktalk/domain/notification/dto/NotificationRepDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/notification/dto/NotificationRepDto.java
@@ -1,0 +1,49 @@
+package com.server.youthtalktalk.domain.notification.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.server.youthtalktalk.domain.notification.entity.*;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record NotificationRepDto(
+        Long notificationId, // 알림 아이디
+        NotificationDetail detail, // 알림 종류
+        String sender, // 다른 사용자
+        Long postId, // 게시글 아이디(게시글 알림 시)
+        Long policyId, // 정책 아이디(정책 알림 시)
+        String title, // 제목
+        String message, // 내용
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime createdAt, // 생성일
+        boolean isCheck, // 알림 확인 여부
+        boolean isRecent // 최근 알림인지 여부(아닐 경우 지난 알림)
+) {
+    public static NotificationRepDto toDto(Notification notification){
+        return NotificationRepDto.builder()
+                .notificationId(notification.getId())
+                .detail(notification.getDetail())
+                .sender(notification.getSender())
+                .postId(notification.getPostId())
+                .policyId(notification.getPolicyId())
+                .message(notification.getMessage())
+                .createdAt(notification.getCreatedAt())
+                .isCheck(notification.isCheck())
+                .isRecent(isRecent(notification))
+                .title(notification.getTitle())
+                .build();
+    }
+
+    private static boolean isRecent(Notification notification) {
+        LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
+        // 최근 알림 기준 : 확인하지 않았으면서, 7일이 지나지 않은 알림
+        return !notification.isCheck() && notification.getCreatedAt().isAfter(sevenDaysAgo);
+    }
+
+}

--- a/src/main/java/com/server/youthtalktalk/domain/notification/entity/Notification.java
+++ b/src/main/java/com/server/youthtalktalk/domain/notification/entity/Notification.java
@@ -1,0 +1,69 @@
+package com.server.youthtalktalk.domain.notification.entity;
+
+import com.server.youthtalktalk.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@RequiredArgsConstructor
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "dtype")
+public class Notification{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private NotificationDetail detail; // 알림 종류
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private NotificationType type; // 정책관련인지, 게시글관련인지 구분
+
+    private Long postId; // 게시글 아이디
+
+    private Long policyId; // 정책 아이디
+
+    @Column(length = 255)
+    private String title; // 알림 제목
+
+    @Column(length = 255)
+    private String message; // 알림 메세지
+
+    @ManyToOne
+    @JoinColumn(name = "receiver_id")
+    private Member receiver; // 수신자
+
+    private String sender; // 송신자 닉네임
+
+    private boolean isCheck; // 알림 확인 여부
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt; // 생성일
+
+    @Builder(toBuilder = true)
+    public Notification(NotificationDetail detail, NotificationType type, Long policyId, Long postId, String title, String message, Member receiver, String sender, boolean isCheck, LocalDateTime createdAt) {
+        this.type = type;
+        this.detail = detail;
+        this.title = title;
+        this.message = message;
+        this.receiver = receiver;
+        this.sender = sender;
+        this.isCheck = isCheck;
+        this.createdAt = createdAt;
+        this.postId = postId;
+        this.policyId = policyId;
+    }
+
+    public void setReceiver(Member receiver) {
+        this.receiver = receiver;
+        if(receiver != null) {
+            receiver.getNotifications().add(this);
+        }
+    }
+
+}

--- a/src/main/java/com/server/youthtalktalk/domain/notification/entity/NotificationDetail.java
+++ b/src/main/java/com/server/youthtalktalk/domain/notification/entity/NotificationDetail.java
@@ -1,0 +1,18 @@
+package com.server.youthtalktalk.domain.notification.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationDetail {
+    POST_COMMENT("notification.POST_COMMENT", null), // 내 게시글 댓글 알림
+    POST_COMMENT_LIKE("notification.POST_COMMENT_LIKE", null), // 게시글에 단 내 댓글 좋아요 알림
+    POLICY_COMMENT_LIKE("notification.POLICY_COMMENT_LIKE", null), // 정책에 단 내 댓글 좋아요 알림
+    TODAY_FINISHED("notification.TODAY_FINISHED.title", "notification.TODAY_FINISHED.content"), // 당일 마감 스크랩 정책 알림
+    WEEK_BEFORE_FINISHED("notification.WEEK_BEFORE_FINISHED.title", "notification.WEEK_BEFORE_FINISHED.content"), // 마감 일주일 전 스크랩 정책 알림
+    WEEK_AFTER_SCRAP("notification.WEEK_AFTER_SCRAP.title", "notification.WEEK_AFTER_SCRAP.content"); // 스크랩한지 일주일 초과 정책 알림
+
+    private final String titleKey;
+    private final String contentKey;
+}

--- a/src/main/java/com/server/youthtalktalk/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/server/youthtalktalk/domain/notification/entity/NotificationType.java
@@ -1,0 +1,9 @@
+package com.server.youthtalktalk.domain.notification.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum NotificationType {
+    POST,
+    POLICY
+}

--- a/src/main/java/com/server/youthtalktalk/domain/notification/entity/SSEEvent.java
+++ b/src/main/java/com/server/youthtalktalk/domain/notification/entity/SSEEvent.java
@@ -1,0 +1,42 @@
+package com.server.youthtalktalk.domain.notification.entity;
+
+import com.server.youthtalktalk.domain.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+public class SSEEvent {
+    private NotificationDetail notificationDetail; // 알림 내용
+    private Member receiver; // 수신자
+    private String sender; // 송신자
+    private String policyTitle; // 정책 제목
+    private NotificationType type; // 알림 타입
+    private Long id; // 정책 또는 게시글 아이디
+    private String comment; // 댓글 내용
+
+    /**
+     * 단일 수신자용 생성자
+     */
+    @Builder
+    public SSEEvent(
+            NotificationDetail detail,
+            Member receiver,
+            String sender,
+            String policyTitle,
+            NotificationType type,
+            Long id,
+            String comment
+    ) {
+        this.notificationDetail = detail;
+        this.receiver = receiver;
+        this.sender = sender;
+        this.policyTitle = policyTitle;
+        this.type = type;
+        this.id = id;
+        this.comment = comment;
+    }
+}

--- a/src/main/java/com/server/youthtalktalk/domain/notification/repository/EmitterRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/notification/repository/EmitterRepository.java
@@ -1,0 +1,16 @@
+package com.server.youthtalktalk.domain.notification.repository;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+
+public interface EmitterRepository {
+    public SseEmitter save(String emitterId, SseEmitter sseEmitter);
+    public void saveEventCache(String emitterId, Object event);
+    public Map<String,SseEmitter> findAllEmitterStartWithByUserId(String userId);
+    public Map<String,Object> findAllEventCacheStartWithByUserId(String userId);
+    public void deleteById(String emitterId);
+    public void deleteAllEmitterStartWithUserId(String userId);
+    public void deleteAllEventCacheStartWithUserId(String userId);
+
+}

--- a/src/main/java/com/server/youthtalktalk/domain/notification/repository/EmitterRepositoryImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/notification/repository/EmitterRepositoryImpl.java
@@ -1,0 +1,62 @@
+package com.server.youthtalktalk.domain.notification.repository;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Repository
+public class EmitterRepositoryImpl implements EmitterRepository{
+    private final Map<String,SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<String,Object> eventCache = new ConcurrentHashMap<>();
+
+    @Override
+    public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
+        emitters.put(emitterId, sseEmitter);
+        return sseEmitter;
+    }
+
+    @Override
+    public void saveEventCache(String emitterId, Object event) {
+        eventCache.put(emitterId, event);
+    }
+
+    @Override
+    public Map<String, SseEmitter> findAllEmitterStartWithByUserId(String userId) {
+        return emitters.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(userId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public Map<String, Object> findAllEventCacheStartWithByUserId(String userId) {
+        return eventCache.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(userId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public void deleteById(String emitterId) {
+        emitters.remove(emitterId);
+    }
+
+    @Override
+    public void deleteAllEmitterStartWithUserId(String userId) {
+        emitters.forEach((key,emitter) -> {
+            if(key.startsWith(userId)) {
+                emitters.remove(key);
+            }
+        });
+    }
+
+    @Override
+    public void deleteAllEventCacheStartWithUserId(String userId) {
+        eventCache.forEach((key,value) -> {
+            if(key.startsWith(userId)) {
+                eventCache.remove(key);
+            }
+        });
+    }
+}

--- a/src/main/java/com/server/youthtalktalk/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,30 @@
+package com.server.youthtalktalk.domain.notification.repository;
+
+import com.server.youthtalktalk.domain.member.entity.Member;
+import com.server.youthtalktalk.domain.notification.entity.Notification;
+import com.server.youthtalktalk.domain.notification.entity.NotificationType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    /** 모든 정책 가져오기 (최근 알림 : 확인하지 않고 7일이 지나지 않은 알림, 지난 알림 : 이외, 시간순 정렬)*/
+    @Query("""
+    SELECT n FROM Notification n WHERE n.receiver = :receiver AND n.type = :type
+    ORDER BY
+        CASE
+            WHEN n.isCheck = false AND n.createdAt > :sevenDaysAgo THEN 0
+            ELSE 1
+        END ASC,
+        n.createdAt DESC
+    """)
+    Page<Notification> findByReceiver(Member receiver, NotificationType type, LocalDateTime sevenDaysAgo, Pageable pageable);
+
+    void deleteAllByReceiverId(Long userId);
+
+}

--- a/src/main/java/com/server/youthtalktalk/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/server/youthtalktalk/domain/notification/service/NotificationService.java
@@ -1,0 +1,12 @@
+package com.server.youthtalktalk.domain.notification.service;
+
+import com.server.youthtalktalk.domain.member.entity.Member;
+import com.server.youthtalktalk.domain.notification.dto.NotificationListRepDto;
+import com.server.youthtalktalk.domain.notification.entity.NotificationType;
+import org.springframework.data.domain.Pageable;
+
+public interface NotificationService {
+    NotificationListRepDto getAllNotificationsByType(Member receiver, NotificationType type, Pageable pageable);
+    void checkNotification(Long notificationId);
+    void deleteNotification(Long notificationId);
+}

--- a/src/main/java/com/server/youthtalktalk/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,77 @@
+package com.server.youthtalktalk.domain.notification.service;
+
+import com.server.youthtalktalk.domain.member.entity.Member;
+import com.server.youthtalktalk.domain.notification.dto.NotificationListRepDto;
+import com.server.youthtalktalk.domain.notification.dto.NotificationRepDto;
+import com.server.youthtalktalk.domain.notification.entity.Notification;
+import com.server.youthtalktalk.domain.notification.entity.NotificationType;
+import com.server.youthtalktalk.domain.notification.repository.NotificationRepository;
+import com.server.youthtalktalk.global.response.exception.notification.NotificationNotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService{
+    private final NotificationRepository notificationRepository;
+
+    /**
+     * 알림 가져오기
+     * POST, POLICY 별로 조회
+     */
+    @Override
+    @Transactional
+    public NotificationListRepDto getAllNotificationsByType(Member receiver, NotificationType type, Pageable pageable) {
+        Pageable pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+
+        // 일주일 전 날짜
+        LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
+        // 최근 알림 -> 지난 알림 -> 시간순 정렬한 알림 목록 가져오기(정책별, 커뮤니티별)
+        Page<Notification> notifications = notificationRepository.findByReceiver(receiver, type, sevenDaysAgo, pageRequest);
+
+        // NotificationDto로 변환
+        return getNotificationListRepDto(notifications);
+    }
+
+    /** 알림 확인하기 */
+    @Override
+    @Transactional
+    public void checkNotification(Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId).orElseThrow(NotificationNotFoundException::new);
+        notificationRepository.save(notification.toBuilder().isCheck(true).build());
+    }
+
+    /** 알림 삭제하기 */
+    @Override
+    @Transactional
+    public void deleteNotification(Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId).orElseThrow(NotificationNotFoundException::new);
+        notificationRepository.delete(notification);
+    }
+
+    private NotificationListRepDto getNotificationListRepDto(Page<Notification> notifications) {
+        // NotificationDto로 변환
+
+        List<NotificationRepDto> responseList = notifications
+                .map(NotificationRepDto::toDto)
+                .stream()
+                .toList();
+
+        return NotificationListRepDto.builder()
+                .notifications(responseList)
+                .page(notifications.getNumber())
+                .total(notifications.getTotalElements())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/server/youthtalktalk/domain/notification/service/SSEService.java
+++ b/src/main/java/com/server/youthtalktalk/domain/notification/service/SSEService.java
@@ -1,0 +1,147 @@
+package com.server.youthtalktalk.domain.notification.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.server.youthtalktalk.domain.member.entity.Member;
+import com.server.youthtalktalk.domain.notification.dto.NotificationRepDto;
+import com.server.youthtalktalk.domain.notification.entity.Notification;
+import com.server.youthtalktalk.domain.notification.entity.NotificationDetail;
+import com.server.youthtalktalk.domain.notification.entity.NotificationType;
+import com.server.youthtalktalk.domain.notification.entity.SSEEvent;
+import com.server.youthtalktalk.domain.notification.repository.EmitterRepository;
+import com.server.youthtalktalk.domain.notification.repository.NotificationRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.MessageSource;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SSEService {
+    private final NotificationRepository notificationRepository;
+    private final EmitterRepository emitterRepository;
+    private final MessageSource messageSource;
+
+    // 연결 지속시간 한 시간
+    private static final Long DEFAULT_TIMEOUT = 60L * 60 * 1000;
+
+    public SseEmitter subscribe(Member user, String lastEventId) {
+        // 고유 아이디 생성
+        String emitterId = user.getId() + "_" + System.currentTimeMillis();
+
+        SseEmitter sseEmitter = emitterRepository.save(emitterId, new SseEmitter(DEFAULT_TIMEOUT));
+        log.info("new emitter added : {}", sseEmitter);
+        log.info("lastEventId : {}", lastEventId);
+
+        /* 상황별 emitter 삭제 처리 */
+        sseEmitter.onCompletion(() -> emitterRepository.deleteById(emitterId)); //완료 시, 타임아웃 시, 에러 발생 시
+        sseEmitter.onTimeout(() -> emitterRepository.deleteById(emitterId));
+        sseEmitter.onError((e) -> emitterRepository.deleteById(emitterId));
+
+        /* 503 Service Unavailable 방지용 dummy event 전송 */
+        sendToClient(sseEmitter, emitterId, "EventStream Created. [userId=" + user.getId() + "]");
+
+        /* client가 미수신한 event 목록이 존재하는 경우 */
+        if(!lastEventId.isEmpty()) { //client가 미수신한 event가 존재하는 경우 이를 전송하여 유실 예방
+            Map<String, Object> eventCaches = emitterRepository.findAllEventCacheStartWithByUserId(String.valueOf(user.getId())); //id에 해당하는 eventCache 조회
+            eventCaches.entrySet().stream() //미수신 상태인 event 목록 전송
+                    .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+                    .forEach(entry -> sendToClient(sseEmitter, entry.getKey(), entry.getValue()));
+        }
+
+        return sseEmitter;
+    }
+
+    @Transactional
+    @EventListener
+    public void send(SSEEvent sseEvent) {
+        // 알램 객체 생성
+        NotificationType type = sseEvent.getType();
+        Long postId = type.equals(NotificationType.POST) ? sseEvent.getId() : null;
+        Long policyId = type.equals(NotificationType.POLICY) ? sseEvent.getId() : null;
+
+        String[] messages = setTitleAndContent(sseEvent.getComment(), sseEvent.getPolicyTitle(), sseEvent.getSender(), sseEvent.getNotificationDetail());
+        String title = messages[0];
+        String message = messages[1];
+
+        Notification notification = Notification.builder()
+                .sender(sseEvent.getSender())
+                .type(type)
+                .createdAt(LocalDateTime.now())
+                .detail(sseEvent.getNotificationDetail())
+                .postId(postId)
+                .policyId(policyId)
+                .isCheck(false)
+                .title(title)
+                .message(message)
+                .build();
+        notification.setReceiver(sseEvent.getReceiver());
+        Notification savedNotification = notificationRepository.save(notification);
+
+        saveEventToUserEmitters(notification.getReceiver().getId(), savedNotification);
+    }
+
+
+    private void saveEventToUserEmitters(Long receiverId, Notification savedNotification) {
+        String userId = String.valueOf(receiverId);
+        // 로그인한 유저의 sseEmitter 전체 호출
+        Map<String,SseEmitter> sseEmitters = emitterRepository.findAllEmitterStartWithByUserId(userId);
+        sseEmitters.forEach(
+                (key,emitter)->{
+                    emitterRepository.saveEventCache(key, savedNotification);
+                    NotificationRepDto response = NotificationRepDto.toDto(savedNotification);
+                    ObjectMapper objectMapper = new ObjectMapper();
+                    String jsonData = null;
+                    try {
+                        jsonData = objectMapper.writeValueAsString(response);
+                    } catch (JsonProcessingException e) {
+                        throw new RuntimeException(e);
+                    }
+                    sendToClient(emitter,key,jsonData);
+                }
+        );
+    }
+
+    private void sendToClient(SseEmitter sseEmitter, String emitterId, Object data) {
+        try{
+            sseEmitter.send(SseEmitter.event()
+                    .id(emitterId)
+                    .data(data));
+        } catch (IOException e) {
+            emitterRepository.deleteById(emitterId);
+            throw new RuntimeException("SSE Connection Failed : 알림 전송 실패");
+        }
+    }
+
+    private String[] setTitleAndContent(String comment, String policyTitle, String sender, NotificationDetail detail){
+        String title = "";
+        String message = "";
+
+        switch(detail){
+            case POST_COMMENT: message = comment;
+            case POST_COMMENT_LIKE:
+            case POLICY_COMMENT_LIKE:
+                title = messageSource.getMessage("notification." + detail.name() + ".title", new Object[]{sender}, null);
+                break;
+
+            case TODAY_FINISHED:
+            case WEEK_BEFORE_FINISHED:
+            case WEEK_AFTER_SCRAP:
+                title = messageSource.getMessage("notification." + detail.name() + ".title", null, null);
+                message = messageSource.getMessage("notification." + detail + ".content", new Object[]{policyTitle}, null);
+                break;
+        }
+
+        return new String[]{title, message};
+    }
+}

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
@@ -25,6 +25,7 @@ import com.server.youthtalktalk.global.response.exception.InvalidValueException;
 import com.server.youthtalktalk.global.response.exception.member.MemberNotFoundException;
 import com.server.youthtalktalk.global.response.exception.policy.PolicyNotFoundException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import lombok.RequiredArgsConstructor;
@@ -397,6 +398,7 @@ public class PolicyServiceImpl implements PolicyService {
                     .itemId(policyId)
                     .itemType(ItemType.POLICY)
                     .member(member)
+                    .createdAt(LocalDateTime.now())
                     .build());
         }
         else{

--- a/src/main/java/com/server/youthtalktalk/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/service/PostServiceImpl.java
@@ -4,6 +4,9 @@ import com.server.youthtalktalk.domain.ItemType;
 import com.server.youthtalktalk.domain.image.entity.PostImage;
 import com.server.youthtalktalk.domain.image.service.ImageService;
 import com.server.youthtalktalk.domain.member.entity.Member;
+import com.server.youthtalktalk.domain.notification.entity.NotificationDetail;
+import com.server.youthtalktalk.domain.notification.entity.NotificationType;
+import com.server.youthtalktalk.domain.notification.entity.SSEEvent;
 import com.server.youthtalktalk.domain.policy.entity.Policy;
 import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
 import com.server.youthtalktalk.domain.post.dto.PostCreateReqDto;
@@ -24,8 +27,10 @@ import com.server.youthtalktalk.global.response.exception.post.PostNotFoundExcep
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,6 +43,7 @@ public class PostServiceImpl implements PostService{
     private final PolicyRepository policyRepository;
     private final ImageService imageService;
     private final ScrapRepository scrapRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     public PostRepDto createPost(PostCreateReqDto postCreateReqDto, Member writer){
@@ -126,11 +132,14 @@ public class PostServiceImpl implements PostService{
             return null;
         }
         else{
-            return scrapRepository.save(Scrap.builder() // 스크랩할 경우
+            Scrap savedScrap = scrapRepository.save(Scrap.builder() // 스크랩할 경우
                     .itemId(postId)
                     .itemType(ItemType.POST)
                     .member(member)
+                    .createdAt(LocalDateTime.now())
                     .build());
+
+            return savedScrap;
         }
     }
 

--- a/src/main/java/com/server/youthtalktalk/domain/scrap/dto/PolicyScrapInfoDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/scrap/dto/PolicyScrapInfoDto.java
@@ -1,0 +1,20 @@
+package com.server.youthtalktalk.domain.scrap.dto;
+
+import com.server.youthtalktalk.domain.member.entity.Member;
+import com.server.youthtalktalk.domain.notification.entity.NotificationDetail;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PolicyScrapInfoDto{
+    private String policyTitle;
+    private Long policyId;
+    private Member member;
+    private LocalDate applyDue;
+    private LocalDateTime scrapCratedAt;
+}

--- a/src/main/java/com/server/youthtalktalk/domain/scrap/entity/Scrap.java
+++ b/src/main/java/com/server/youthtalktalk/domain/scrap/entity/Scrap.java
@@ -1,5 +1,6 @@
 package com.server.youthtalktalk.domain.scrap.entity;
 
+import com.server.youthtalktalk.domain.BaseTimeEntity;
 import com.server.youthtalktalk.domain.ItemType;
 import com.server.youthtalktalk.domain.member.entity.Member;
 import jakarta.persistence.*;
@@ -8,11 +9,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Scrap {
-
+public class Scrap{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "scrap_id")
@@ -27,10 +29,13 @@ public class Scrap {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    private LocalDateTime createdAt;
+
     @Builder(toBuilder = true)
-    public Scrap(ItemType itemType, Long itemId, Member member) {
+    public Scrap(ItemType itemType, Long itemId, Member member, LocalDateTime createdAt) {
         this.itemType = itemType;
         this.itemId = itemId;
         this.member = member;
+        this.createdAt = createdAt;
     }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/scrap/repository/ScrapRepository.java
@@ -5,15 +5,15 @@ import com.server.youthtalktalk.domain.ItemType;
 import com.server.youthtalktalk.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
 import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface ScrapRepository extends JpaRepository<Scrap, Long> {
+public interface ScrapRepository extends JpaRepository<Scrap, Long>, ScrapRepositoryCustom{
     // 특정 사용자가 특정 타입의 아이템을 스크랩했는지의 여부
     boolean existsByMemberIdAndItemIdAndItemType(Long memberId, Long itemId, ItemType itemType);
     Optional<Scrap> findByMemberAndItemIdAndItemType(Member memberId, Long itemId, ItemType itemType);
     List<Scrap> findAllByItemIdAndItemType(Long itemId, ItemType itemType);
     void deleteAllByItemIdAndItemType(Long itemId, ItemType itemType);
+    // 정책 마감일로 조회
 }

--- a/src/main/java/com/server/youthtalktalk/domain/scrap/repository/ScrapRepositoryCustom.java
+++ b/src/main/java/com/server/youthtalktalk/domain/scrap/repository/ScrapRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.server.youthtalktalk.domain.scrap.repository;
+
+import com.server.youthtalktalk.domain.ItemType;
+import com.server.youthtalktalk.domain.scrap.dto.PolicyScrapInfoDto;
+import org.springframework.data.domain.Pageable;
+import java.util.List;
+
+public interface ScrapRepositoryCustom {
+    List<PolicyScrapInfoDto> findRecentByDeadlineOrScrapDate();
+}

--- a/src/main/java/com/server/youthtalktalk/domain/scrap/repository/ScrapRepositoryCustomImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/scrap/repository/ScrapRepositoryCustomImpl.java
@@ -1,0 +1,53 @@
+package com.server.youthtalktalk.domain.scrap.repository;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.server.youthtalktalk.domain.ItemType;
+import com.server.youthtalktalk.domain.notification.entity.NotificationDetail;
+import com.server.youthtalktalk.domain.policy.entity.QPolicy;
+import com.server.youthtalktalk.domain.scrap.dto.PolicyScrapInfoDto;
+import com.server.youthtalktalk.domain.scrap.entity.QScrap;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ScrapRepositoryCustomImpl implements ScrapRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+    QPolicy policy = QPolicy.policy;
+    QScrap scrap = QScrap.scrap;
+
+    @Override
+    public List<PolicyScrapInfoDto> findRecentByDeadlineOrScrapDate() {
+        List<PolicyScrapInfoDto> results = queryFactory
+                .select(Projections.constructor(
+                        PolicyScrapInfoDto.class,
+                        policy.title,        // String policyTitle
+                        policy.policyId,           // Long policyId
+                        scrap.member,                   // member
+                        policy.applyDue,
+                        scrap.createdAt
+                ))
+                .from(policy)
+                .join(scrap).on(policy.policyId.eq(scrap.itemId))
+                .where(
+                        scrap.itemType.eq(ItemType.POLICY),
+                        // 마감일이 당일이거나 일주일 후
+                        policy.applyDue.eq(LocalDate.now())
+                        .or(policy.applyDue.eq(LocalDate.now().plusDays(7)))
+                        // 또는 스크랩한 지 일주일이 지났을 때
+                        .or(scrap.createdAt.before(LocalDateTime.now().minusDays(7)))
+
+                )
+                .fetch();
+
+        return results;
+    }
+}

--- a/src/main/java/com/server/youthtalktalk/domain/scrap/repository/ScrapRepositoryCustomImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/scrap/repository/ScrapRepositoryCustomImpl.java
@@ -43,7 +43,7 @@ public class ScrapRepositoryCustomImpl implements ScrapRepositoryCustom {
                         policy.applyDue.eq(LocalDate.now())
                         .or(policy.applyDue.eq(LocalDate.now().plusDays(7)))
                         // 또는 스크랩한 지 일주일이 지났을 때
-                        .or(scrap.createdAt.before(LocalDateTime.now().minusDays(7)))
+                        .or(scrap.createdAt.eq(LocalDateTime.now().minusDays(7)))
 
                 )
                 .fetch();

--- a/src/main/java/com/server/youthtalktalk/domain/scrap/service/ScrapService.java
+++ b/src/main/java/com/server/youthtalktalk/domain/scrap/service/ScrapService.java
@@ -1,0 +1,5 @@
+package com.server.youthtalktalk.domain.scrap.service;
+
+public interface ScrapService {
+    void sendScrapedPolicyNotification();
+}

--- a/src/main/java/com/server/youthtalktalk/domain/scrap/service/ScrapServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/scrap/service/ScrapServiceImpl.java
@@ -1,0 +1,64 @@
+package com.server.youthtalktalk.domain.scrap.service;
+
+import com.server.youthtalktalk.domain.notification.entity.NotificationDetail;
+import com.server.youthtalktalk.domain.notification.entity.NotificationType;
+import com.server.youthtalktalk.domain.notification.entity.SSEEvent;
+import com.server.youthtalktalk.domain.scrap.dto.PolicyScrapInfoDto;
+import com.server.youthtalktalk.domain.scrap.repository.ScrapRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ScrapServiceImpl implements ScrapService {
+    private final ScrapRepository scrapRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Scheduled(cron = "0 0 9 * * ?")  // 매일 9시 정각에 실행
+    //@Scheduled(cron = "0 * * * * *")  // 매분 0초에 실행(테스트용)
+    @Override
+    @Transactional
+    public void sendScrapedPolicyNotification() {
+        List<PolicyScrapInfoDto> infoList = scrapRepository.findRecentByDeadlineOrScrapDate();
+        for (PolicyScrapInfoDto info : infoList) {
+            SSEEvent event = SSEEvent.builder()
+                    .id(info.getPolicyId())
+                    .type(NotificationType.POLICY)
+                    .detail(getNotificationDetail(info.getApplyDue(), info.getScrapCratedAt()))
+                    .comment(null)
+                    .receiver(info.getMember())
+                    .sender(null)
+                    .policyTitle(info.getPolicyTitle())
+                    .build();
+            applicationEventPublisher.publishEvent(event);
+        }
+    }
+
+    private NotificationDetail getNotificationDetail(LocalDate applyDue, LocalDateTime scrapCreatedAt) {
+        // 오늘 마감일인 경우
+        if (applyDue.equals(LocalDate.now())) {
+            return NotificationDetail.TODAY_FINISHED;
+        }
+
+        // 마감일이 일주일 후인 경우
+        else if (applyDue.equals(LocalDate.now().plusDays(7))) {
+            return NotificationDetail.WEEK_BEFORE_FINISHED;
+        }
+
+        // 스크랩한 지 일주일이 지난 경우
+        else if (scrapCreatedAt.isBefore(LocalDateTime.now().minusDays(7))) {
+            return NotificationDetail.WEEK_AFTER_SCRAP;
+        }
+
+        // 기본값
+        return NotificationDetail.TODAY_FINISHED;
+    }
+}

--- a/src/main/java/com/server/youthtalktalk/global/batch/BatchScheduler.java
+++ b/src/main/java/com/server/youthtalktalk/global/batch/BatchScheduler.java
@@ -9,21 +9,22 @@ import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
 import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
 import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
-@Component
-public class DeleteImgScheduler {
+@Configuration
+public class BatchScheduler {
     private final JobLauncher jobLauncher;
-    private final Job job;
+    private final Job deleteImgJob;
 
     @Async(value = "asyncTask")
     @Scheduled(cron = "0 0 0 * * SUN") // 매주 일요일 자정 실행
     public void runDeleteImgJob()
             throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException, JobRestartException {
-        jobLauncher.run(job, new JobParametersBuilder()
+        jobLauncher.run(deleteImgJob, new JobParametersBuilder()
                 .addLong("timestamp", System.currentTimeMillis()) // 유니크 파라미터 추가
                 .toJobParameters());
     }

--- a/src/main/java/com/server/youthtalktalk/global/config/BatchConfig.java
+++ b/src/main/java/com/server/youthtalktalk/global/config/BatchConfig.java
@@ -1,15 +1,20 @@
 package com.server.youthtalktalk.global.config;
 
+import com.server.youthtalktalk.domain.scrap.dto.PolicyScrapInfoDto;
+import com.server.youthtalktalk.domain.scrap.repository.ScrapRepository;
 import com.server.youthtalktalk.global.batch.DeleteImgTasklet;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.data.RepositoryItemReader;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
 import org.springframework.boot.autoconfigure.batch.BatchProperties;
 import org.springframework.boot.autoconfigure.batch.JobLauncherApplicationRunner;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -17,8 +22,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.util.StringUtils;
+
+import java.util.Collections;
 
 @Slf4j
 @Configuration
@@ -26,6 +34,7 @@ import org.springframework.util.StringUtils;
 @EnableConfigurationProperties(BatchProperties.class)
 public class BatchConfig {
     private final DeleteImgTasklet deleteImgTasklet;
+    private final ScrapRepository scrapRepository;
 
     @Bean
     @ConditionalOnMissingBean
@@ -40,6 +49,7 @@ public class BatchConfig {
         return runner;
     }
 
+    // S3 이미지 삭제 스케줄링(Tasklet 기반)
     @Bean
     public Job deleteImgJob(JobRepository jobRepository, PlatformTransactionManager transactionManager){
         return new JobBuilder("deleteImgJob", jobRepository)

--- a/src/main/java/com/server/youthtalktalk/global/config/JacksonConfig.java
+++ b/src/main/java/com/server/youthtalktalk/global/config/JacksonConfig.java
@@ -1,0 +1,18 @@
+package com.server.youthtalktalk.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper;
+    }
+}

--- a/src/main/java/com/server/youthtalktalk/global/response/BaseResponseCode.java
+++ b/src/main/java/com/server/youthtalktalk/global/response/BaseResponseCode.java
@@ -97,7 +97,11 @@ public enum BaseResponseCode {
 
     // Report
     REPORT_ALREADY_EXISTENCE_EXCEPTION("R01","이미 신고한 게시글입니다.",HttpStatus.CONFLICT.value()),
-    SELF_REPORT_NOT_ALLOWED_EXCEPTION("R02", "본인의 게시글은 신고할 수 없습니다.", HttpStatus.BAD_REQUEST.value());
+    SELF_REPORT_NOT_ALLOWED_EXCEPTION("R02", "본인의 게시글은 신고할 수 없습니다.", HttpStatus.BAD_REQUEST.value()),
+
+    // Notification
+    NOTIFICATION_NOT_FOUND_EXCEPTION("N01", "존재하지 않는 알림입니다.", HttpStatus.NOT_FOUND.value());
+
 
     private final String code;
     private final String message;

--- a/src/main/java/com/server/youthtalktalk/global/response/exception/notification/NotificationNotFoundException.java
+++ b/src/main/java/com/server/youthtalktalk/global/response/exception/notification/NotificationNotFoundException.java
@@ -1,0 +1,10 @@
+package com.server.youthtalktalk.global.response.exception.notification;
+
+import com.server.youthtalktalk.global.response.BaseResponseCode;
+import com.server.youthtalktalk.global.response.exception.BusinessException;
+
+public class NotificationNotFoundException extends BusinessException {
+    public NotificationNotFoundException() {
+        super(BaseResponseCode.NOTIFICATION_NOT_FOUND_EXCEPTION);
+    }
+}


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #34 

### ⛳ 작업 분류
- [x] 앱 실시간 푸시 알림 기능 구현

### 🔨 작업 상세 내용
1. 자유 게시글 댓글 등록 시 작성자에게 알림
2. 자유 게시글 댓글 좋아요 시 댓글 작성자에게 알림
3. 정책 게시글 댓글 좋아요 시 댓글 작성자에게 알림
4. 스크랩한 정책이 당일 마감인 경우 알림(스케줄링)
5. 스크랩한 정책이 일주일 후 마감인 경우 알림(스케줄링)
6. 스크랩한지 7일이 지나면 알림(스케줄링)

### 📍 참고 사항
- **매일 오전 9시에 알림 스케줄링 서비스 실행** : 알림은 사용자 확인이 중요하다고 생각했습니다. 대부분 활동 시작을 9시부터 한다고 생각해서 우선 아침 9시로 설정했습니다! 
- QueryDSL로 스크랩과 정책 조인하여 구현했습니다. 
현재는 정책을 스크랩할 시 Scrap 엔티티에 **itemType, itemId로만 설정돼있고, 특별히 연관관계 매핑을 이용하지 않고 있습니다.** 
정책과 조인관계를 맺었다면 알림 스케줄링 부분의 쿼리를 더 최적화할 수 있다고 생각했지만, 개발 기한도 얼마 안 남았고 아직 상의되지 않은 부분이라 디비 변경없이 구현했습니다.
- Spring Batch 적용해서 스케줄링 서비스의 효율을 높이려고 했으나, 이미 다른 job이 존재하는 상황에서 충돌이나 설정 등의 복잡한 문제가 발생하여 일단 batch 적용없이 스케줄링만 적용해서 구현했습니다. 추후에 다시 알아보겠습니다.
