### PR TITLE
[FEAT] 실시간 정책 조회 API 구현

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/policy/controller/PolicyController.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/controller/PolicyController.java
@@ -3,11 +3,12 @@ package com.server.youthtalktalk.domain.policy.controller;
 import static com.server.youthtalktalk.global.response.BaseResponseCode.*;
 
 import com.server.youthtalktalk.domain.policy.entity.Category;
+import com.server.youthtalktalk.domain.member.service.MemberService;
 import com.server.youthtalktalk.domain.policy.dto.*;
 import com.server.youthtalktalk.domain.policy.entity.SortOption;
 import com.server.youthtalktalk.global.response.BaseResponse;
-import com.server.youthtalktalk.domain.member.service.MemberService;
 import com.server.youthtalktalk.domain.policy.service.PolicyService;
+import com.server.youthtalktalk.global.response.BaseResponseCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;

--- a/src/main/java/com/server/youthtalktalk/domain/policy/controller/PolicyController.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/controller/PolicyController.java
@@ -1,10 +1,11 @@
 package com.server.youthtalktalk.domain.policy.controller;
 
+import static com.server.youthtalktalk.global.response.BaseResponseCode.*;
+
 import com.server.youthtalktalk.domain.policy.entity.Category;
 import com.server.youthtalktalk.domain.policy.dto.*;
 import com.server.youthtalktalk.domain.policy.entity.SortOption;
 import com.server.youthtalktalk.global.response.BaseResponse;
-import com.server.youthtalktalk.global.response.BaseResponseCode;
 import com.server.youthtalktalk.domain.member.service.MemberService;
 import com.server.youthtalktalk.domain.policy.service.PolicyService;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +40,7 @@ public class PolicyController {
         responseMap.put("top5Policies", top5Policies);
         responseMap.put("allPolicies", allPolicies);
 
-        return new BaseResponse<>(responseMap, BaseResponseCode.SUCCESS_POLICY_FOUND);
+        return new BaseResponse<>(responseMap, SUCCESS_POLICY_FOUND);
     }
 
     /**
@@ -48,7 +49,7 @@ public class PolicyController {
     @GetMapping("/policies/{id}")
     public BaseResponse<PolicyDetailResponseDto> getPolicyDetail(@PathVariable Long id) {
         PolicyDetailResponseDto policyDetail = policyService.getPolicyDetail(id);
-        return new BaseResponse<>(policyDetail, BaseResponseCode.SUCCESS_POLICY_FOUND);
+        return new BaseResponse<>(policyDetail, SUCCESS_POLICY_FOUND);
     }
 
     /**
@@ -57,9 +58,9 @@ public class PolicyController {
     @PostMapping("/policies/{id}/scrap")
     public BaseResponse<String> scrap(@PathVariable Long id){
         if(policyService.scrapPolicy(id,memberService.getCurrentMember())!=null)
-            return new BaseResponse<>(BaseResponseCode.SUCCESS_SCRAP);
+            return new BaseResponse<>(SUCCESS_SCRAP);
         else
-            return new BaseResponse<>(BaseResponseCode.SUCCESS_SCRAP_CANCEL);
+            return new BaseResponse<>(SUCCESS_SCRAP_CANCEL);
     }
 
     /**
@@ -68,7 +69,7 @@ public class PolicyController {
     @GetMapping("/policies/scrap")
     public BaseResponse<List<PolicyListResponseDto>> getMyScrapedPolicies(@PageableDefault(size = 10) Pageable pageable){
         List<PolicyListResponseDto> listResponseDto = policyService.getScrapPolicies(pageable,memberService.getCurrentMember());
-        return new BaseResponse<>(listResponseDto, BaseResponseCode.SUCCESS);
+        return new BaseResponse<>(listResponseDto, SUCCESS);
     }
 
     /**
@@ -84,9 +85,9 @@ public class PolicyController {
         Pageable pageable = PageRequest.of(page, size);
         SearchConditionResponseDto listResponseDto = policyService.getPoliciesByCondition(request, pageable, sort);
         if (listResponseDto.getPolicyList().isEmpty()) {
-            return new BaseResponse<>(listResponseDto, BaseResponseCode.SUCCESS_POLICY_SEARCH_NO_RESULT);
+            return new BaseResponse<>(listResponseDto, SUCCESS_POLICY_SEARCH_NO_RESULT);
         }
-        return new BaseResponse<>(listResponseDto, BaseResponseCode.SUCCESS_POLICY_FOUND);
+        return new BaseResponse<>(listResponseDto, SUCCESS_POLICY_FOUND);
     }
 
     /**
@@ -99,8 +100,8 @@ public class PolicyController {
         Pageable pageable = PageRequest.of(page, size);
         List<SearchNameResponseDto> listResponseDto = policyService.getPoliciesByName(title, pageable);
         if(listResponseDto.isEmpty())
-            return new BaseResponse<>(listResponseDto, BaseResponseCode.SUCCESS_POLICY_SEARCH_NO_RESULT);
-        return new BaseResponse<>(listResponseDto, BaseResponseCode.SUCCESS_POLICY_FOUND);
+            return new BaseResponse<>(listResponseDto, SUCCESS_POLICY_SEARCH_NO_RESULT);
+        return new BaseResponse<>(listResponseDto, SUCCESS_POLICY_FOUND);
     }
 
     /**
@@ -109,7 +110,16 @@ public class PolicyController {
     @GetMapping("/policies/scrapped/upcoming-deadline")
     public BaseResponse<List<PolicyListResponseDto>> getScrappedPoliciesWithUpcomingDeadline() {
         List<PolicyListResponseDto> listResponseDto = policyService.getScrappedPoliciesWithUpcomingDeadline(memberService.getCurrentMember());
-        return new BaseResponse<>(listResponseDto, BaseResponseCode.SUCCESS);
+        return new BaseResponse<>(listResponseDto, SUCCESS);
+    }
+
+    /**
+     * 조회수 top5 정책 조회 (최대 5개, 정책별로 후기게시글 같이 반환)
+     */
+    @GetMapping("/policies/top5-with-reviews")
+    public BaseResponse<List<PolicyWithReviewsDto>> getTop5PoliciesWithReviews() {
+        List<PolicyWithReviewsDto> top5PoliciesWithReviews = policyService.getTop5PoliciesWithReviews(memberService.getCurrentMember());
+        return new BaseResponse<>(top5PoliciesWithReviews, SUCCESS);
     }
 
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/PolicyWithReviewsDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/PolicyWithReviewsDto.java
@@ -1,0 +1,11 @@
+package com.server.youthtalktalk.domain.policy.dto;
+
+import java.util.List;
+
+public record PolicyWithReviewsDto(
+        Long policyId,
+        String title,
+        String imgUrl,
+        List<ReviewInPolicyDto> reviews
+) {
+}

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/ReviewInPolicyDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/ReviewInPolicyDto.java
@@ -1,0 +1,13 @@
+package com.server.youthtalktalk.domain.policy.dto;
+
+import java.time.LocalDate;
+
+public record ReviewInPolicyDto(
+        Long postId,
+        String title,
+        String contentPreview,
+        int commentCount,
+        int scrapCount,
+        LocalDate createdAt
+) {
+}

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/ReviewInPolicyDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/ReviewInPolicyDto.java
@@ -6,8 +6,8 @@ public record ReviewInPolicyDto(
         Long postId,
         String title,
         String contentPreview,
-        int commentCount,
-        int scrapCount,
+        long commentCount,
+        long scrapCount,
         LocalDate createdAt
 ) {
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyRepository.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 public interface PolicyRepository extends JpaRepository<Policy,String>, PolicyQueryRepository {
 
     /**
-     * top5 정책 조회 (조회수순)
+     * 지역 기반 top5 정책 조회 (조회수순)
      */
     @Query("SELECT p FROM Policy p WHERE p.region = :region OR p.region = 'ALL' ORDER BY p.view DESC")
     Page<Policy> findTop5ByRegionOrderByViewsDesc(@Param("region") Region region, Pageable pageable);
@@ -59,4 +59,9 @@ public interface PolicyRepository extends JpaRepository<Policy,String>, PolicyQu
      * policyId로 정책 존재 여부 검사
      */
     boolean existsByPolicyId(Long policyId);
+
+    /**
+     * 조회수 top5 정책 조회
+     */
+    List<Policy> findTop5ByOrderByViewDesc();
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyRepository.java
@@ -18,7 +18,8 @@ import java.util.Optional;
 public interface PolicyRepository extends JpaRepository<Policy,String>, PolicyQueryRepository {
 
     /**
-     * 지역 기반 top5 정책 조회 (조회수순)
+     * top20 정책 조회 (조회수순)
+     * 여러 지역 선택 가능
      */
     @Query("SELECT p FROM Policy p WHERE p.region = :region OR p.region = 'ALL' ORDER BY p.view DESC")
     Page<Policy> findTop5ByRegionOrderByViewsDesc(@Param("region") Region region, Pageable pageable);

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyService.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyService.java
@@ -18,4 +18,5 @@ public interface PolicyService {
     Scrap scrapPolicy(Long policyId, Member member);
     List<PolicyListResponseDto> getScrapPolicies(Pageable pageable,Member member);
     List<PolicyListResponseDto> getScrappedPoliciesWithUpcomingDeadline(Member member);
+    List<PolicyWithReviewsDto> getTop5PoliciesWithReviews(Member member);
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
@@ -13,6 +13,7 @@ import com.server.youthtalktalk.domain.policy.repository.region.SubRegionReposit
 import com.server.youthtalktalk.domain.post.entity.Post;
 import com.server.youthtalktalk.domain.post.repostiory.PostRepositoryCustomImpl;
 import com.server.youthtalktalk.domain.scrap.entity.Scrap;
+import com.server.youthtalktalk.domain.ItemType;
 import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.member.service.MemberService;
 import com.server.youthtalktalk.domain.policy.dto.*;
@@ -462,7 +463,7 @@ public class PolicyServiceImpl implements PolicyService {
 
     private ReviewInPolicyDto toReviewInPolicyDto(Post review) {
         // 후기글의 스크랩 수 조회
-        int scrapCount = scrapRepository.countByItemIdAndItemType(review.getId(), POST);
+        long scrapCount = scrapRepository.countByItemTypeAndItemId(POST, review.getId());
 
         return new ReviewInPolicyDto(
                 review.getId(), // 게시글 id

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
@@ -1,6 +1,5 @@
 package com.server.youthtalktalk.domain.policy.service;
 
-import com.server.youthtalktalk.domain.ItemType;
 import com.server.youthtalktalk.domain.policy.dto.SearchConditionDto;
 import com.server.youthtalktalk.domain.policy.entity.InstitutionType;
 import com.server.youthtalktalk.domain.policy.entity.SortOption;
@@ -11,6 +10,8 @@ import com.server.youthtalktalk.domain.policy.entity.condition.Marriage;
 import com.server.youthtalktalk.domain.policy.entity.condition.Specialization;
 import com.server.youthtalktalk.domain.policy.entity.region.SubRegion;
 import com.server.youthtalktalk.domain.policy.repository.region.SubRegionRepository;
+import com.server.youthtalktalk.domain.post.entity.Post;
+import com.server.youthtalktalk.domain.post.repostiory.PostRepositoryCustomImpl;
 import com.server.youthtalktalk.domain.scrap.entity.Scrap;
 import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.member.service.MemberService;
@@ -20,7 +21,6 @@ import com.server.youthtalktalk.domain.policy.entity.Policy;
 import com.server.youthtalktalk.domain.policy.entity.region.Region;
 import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
 import com.server.youthtalktalk.domain.scrap.repository.ScrapRepository;
-import com.server.youthtalktalk.global.response.BaseResponseCode;
 import com.server.youthtalktalk.global.response.exception.InvalidValueException;
 import com.server.youthtalktalk.global.response.exception.member.MemberNotFoundException;
 import com.server.youthtalktalk.global.response.exception.policy.PolicyNotFoundException;
@@ -38,6 +38,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.server.youthtalktalk.domain.ItemType.*;
 import static com.server.youthtalktalk.global.response.BaseResponseCode.*;
 
 @Service
@@ -51,11 +52,13 @@ public class PolicyServiceImpl implements PolicyService {
     public static final int MIN_EARN_INPUT = 0;
     public static final int MAX_EARN_INPUT = 50_000_000;
     public static final String APPLY_DUE_FORMAT = "yyyy-MM-dd";
+    public static final int POST_PREVIEW_MAX_LENGTH = 50;
 
     private final PolicyRepository policyRepository;
     private final ScrapRepository scrapRepository;
     private final MemberService memberService;
     private final SubRegionRepository subRegionRepository;
+    private final PostRepositoryCustomImpl postRepository;
 
     /**
      * top 5 정책 조회
@@ -79,7 +82,7 @@ public class PolicyServiceImpl implements PolicyService {
 
         List<PolicyListResponseDto> result = policies.stream()
                 .map(policy -> {
-                    boolean isScrap = scrapRepository.existsByMemberIdAndItemIdAndItemType(memberId, policy.getPolicyId(), ItemType.POLICY);
+                    boolean isScrap = scrapRepository.existsByMemberIdAndItemIdAndItemType(memberId, policy.getPolicyId(), POLICY);
                     return PolicyListResponseDto.toListDto(policy, isScrap);
                 })
                 .collect(Collectors.toList());
@@ -108,7 +111,7 @@ public class PolicyServiceImpl implements PolicyService {
         }
         List<PolicyListResponseDto> result =  policies.stream()
                 .map(policy -> {
-                    boolean isScrap = scrapRepository.existsByMemberIdAndItemIdAndItemType(memberId, policy.getPolicyId(), ItemType.POLICY);
+                    boolean isScrap = scrapRepository.existsByMemberIdAndItemIdAndItemType(memberId, policy.getPolicyId(), POLICY);
                     return PolicyListResponseDto.toListDto(policy, isScrap);
                 })
                 .collect(Collectors.toList());
@@ -134,7 +137,7 @@ public class PolicyServiceImpl implements PolicyService {
 
         policyRepository.save(policy.toBuilder().view(policy.getView()+1).build());
 
-        boolean isScrap = scrapRepository.existsByMemberIdAndItemIdAndItemType(memberId, policy.getPolicyId(), ItemType.POLICY);
+        boolean isScrap = scrapRepository.existsByMemberIdAndItemIdAndItemType(memberId, policy.getPolicyId(), POLICY);
         PolicyDetailResponseDto result = PolicyDetailResponseDto.toDto(policy, isScrap);
         log.info("특정 정책 세부 조회 성공");
         return result;
@@ -155,7 +158,7 @@ public class PolicyServiceImpl implements PolicyService {
         List<PolicyListResponseDto> result = policies.stream()
                 .map(policy -> {
                     boolean isScrap = scrapRepository.existsByMemberIdAndItemIdAndItemType(
-                            memberService.getCurrentMember().getId(), policy.getPolicyId(), ItemType.POLICY);
+                            memberService.getCurrentMember().getId(), policy.getPolicyId(), POLICY);
                     return PolicyListResponseDto.toListDto(policy, isScrap);
                 })
                 .collect(Collectors.toList());
@@ -391,11 +394,11 @@ public class PolicyServiceImpl implements PolicyService {
     @Override
     public Scrap scrapPolicy(Long policyId, Member member) {
         policyRepository.findByPolicyId(policyId).orElseThrow(PolicyNotFoundException::new); // 정책 존재 유무
-        Scrap scrap = scrapRepository.findByMemberAndItemIdAndItemType(member,policyId, ItemType.POLICY).orElse(null);
+        Scrap scrap = scrapRepository.findByMemberAndItemIdAndItemType(member,policyId, POLICY).orElse(null);
         if(scrap == null){
             return scrapRepository.save(Scrap.builder() // 스크랩할 경우
                     .itemId(policyId)
-                    .itemType(ItemType.POLICY)
+                    .itemType(POLICY)
                     .member(member)
                     .build());
         }
@@ -430,6 +433,51 @@ public class PolicyServiceImpl implements PolicyService {
                     return PolicyListResponseDto.toListDto(policy, isScrap);
                 })
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<PolicyWithReviewsDto> getTop5PoliciesWithReviews(Member member) {
+        List<Policy> topPolicies = policyRepository.findTop5ByOrderByViewDesc();
+
+        return topPolicies.stream()
+                .map(policy -> toPolicyWithReviewsDto(member, policy))
+                .toList();
+    }
+
+    private PolicyWithReviewsDto toPolicyWithReviewsDto(Member member, Policy policy) {
+        // 정책의 후기글 중에서 조회수 top3 조회
+        List<Post> topReviews = postRepository.findTopReviewsByPolicy(member, policy, 3);
+
+        List<ReviewInPolicyDto> reviews = topReviews.stream()
+                .map(this::toReviewInPolicyDto)
+                .toList();
+
+        return new PolicyWithReviewsDto(
+                policy.getPolicyId(), // 정책 id
+                policy.getTitle(), // 정책 제목
+                policy.getDepartment().getImage_url(), // 정책 이미지 URL
+                reviews // 정책의 인기 후기글 목록 (조회수 기준 top3)
+        );
+    }
+
+    private ReviewInPolicyDto toReviewInPolicyDto(Post review) {
+        // 후기글의 스크랩 수 조회
+        int scrapCount = scrapRepository.countByItemIdAndItemType(review.getId(), POST);
+
+        return new ReviewInPolicyDto(
+                review.getId(), // 게시글 id
+                review.getTitle(), // 게시글 제목
+                createContentSnippet(review.getContent()), // 내용 미리보기
+                review.getPostComments().size(), // 댓글 수
+                scrapCount, // 스크랩 수
+                review.getCreatedAt().toLocalDate() // 작성일
+        );
+    }
+
+    private String createContentSnippet(String content) {
+        return content.length() > POST_PREVIEW_MAX_LENGTH
+                ? content.substring(0, POST_PREVIEW_MAX_LENGTH) + "..."
+                : content;
     }
 
 }

--- a/src/main/java/com/server/youthtalktalk/domain/post/repostiory/PostRepositoryCustom.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/repostiory/PostRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.server.youthtalktalk.domain.post.repostiory;
 
 import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.policy.entity.Category;
+import com.server.youthtalktalk.domain.policy.entity.Policy;
 import com.server.youthtalktalk.domain.post.entity.Post;
 import com.server.youthtalktalk.domain.post.entity.Review;
 import org.springframework.data.domain.Page;
@@ -28,4 +29,6 @@ public interface PostRepositoryCustom {
     Page<Post> findAllReviewsByKeyword(Member member, String keyword, Pageable pageable);
     /** 스크랩한 게시글 검색*/
     Page<Post> findAllByScrap(Member member, Pageable pageable);
+    /** 특정 정책의 리뷰 Top N개 조회수순 검색*/
+    List<Post> findTopReviewsByPolicy(Member member, Policy policy, int top);
 }

--- a/src/main/java/com/server/youthtalktalk/domain/post/repostiory/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/repostiory/PostRepositoryCustomImpl.java
@@ -8,6 +8,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.member.entity.QBlock;
 import com.server.youthtalktalk.domain.policy.entity.Category;
+import com.server.youthtalktalk.domain.policy.entity.Policy;
 import com.server.youthtalktalk.domain.post.entity.Post;
 import com.server.youthtalktalk.domain.post.entity.QPost;
 import com.server.youthtalktalk.domain.post.entity.QReview;
@@ -211,6 +212,21 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                 .fetchOne();
 
         return new PageImpl<>(posts, pageable, total == null ? 0 : total);
+    }
+
+    @Override
+    public List<Post> findTopReviewsByPolicy(Member member, Policy policy, int top) {
+        return queryFactory
+                .selectFrom(post)
+                .leftJoin(block).on(blockJoinWithPost(member))
+                .leftJoin(report).on(reportJoinWithPost(member))
+                .where(
+                        review.policy.eq(policy),
+                        reviewConditionsExcludeReportAndBlocked()
+                )
+                .orderBy(review.view.desc())
+                .limit(top)
+                .fetch();
     }
 
     BooleanExpression blockJoinWithPost(Member member){

--- a/src/main/java/com/server/youthtalktalk/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/scrap/repository/ScrapRepository.java
@@ -11,9 +11,9 @@ import java.util.Optional;
 
 @Repository
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
-    // 특정 사용자가 특정 타입의 아이템을 스크랩했는지의 여부
-    boolean existsByMemberIdAndItemIdAndItemType(Long memberId, Long itemId, ItemType itemType);
+    boolean existsByMemberIdAndItemIdAndItemType(Long memberId, Long itemId, ItemType itemType); // 특정 사용자가 특정 타입의 아이템을 스크랩했는지의 여부
     Optional<Scrap> findByMemberAndItemIdAndItemType(Member memberId, Long itemId, ItemType itemType);
     List<Scrap> findAllByItemIdAndItemType(Long itemId, ItemType itemType);
     void deleteAllByItemIdAndItemType(Long itemId, ItemType itemType);
+    int countByItemIdAndItemType(Long itemId, ItemType itemType);
 }

--- a/src/main/java/com/server/youthtalktalk/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/scrap/repository/ScrapRepository.java
@@ -15,5 +15,5 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     Optional<Scrap> findByMemberAndItemIdAndItemType(Member memberId, Long itemId, ItemType itemType);
     List<Scrap> findAllByItemIdAndItemType(Long itemId, ItemType itemType);
     void deleteAllByItemIdAndItemType(Long itemId, ItemType itemType);
-    int countByItemIdAndItemType(Long itemId, ItemType itemType);
+    long countByItemTypeAndItemId(ItemType itemType, Long itemId);
 }

--- a/src/test/java/com/server/youthtalktalk/repository/policy/PolicyRepositoryTest.java
+++ b/src/test/java/com/server/youthtalktalk/repository/policy/PolicyRepositoryTest.java
@@ -1,0 +1,54 @@
+package com.server.youthtalktalk.repository.policy;
+
+import static com.server.youthtalktalk.domain.policy.entity.InstitutionType.*;
+import static com.server.youthtalktalk.domain.policy.entity.RepeatCode.PERIOD;
+import static com.server.youthtalktalk.domain.policy.entity.condition.Marriage.SINGLE;
+import static com.server.youthtalktalk.domain.policy.entity.region.Region.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.server.youthtalktalk.domain.policy.entity.Policy;
+import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+public class PolicyRepositoryTest {
+
+    @Autowired
+    private PolicyRepository policyRepository;
+
+    @Test
+    @DisplayName("조회수가 가장 높은 5개의 정책을 정렬하여 반환한다.")
+    void testFindTop5ByOrderByViewDesc() {
+        // given
+        for (int i = 1; i <= 10; i++) {
+            Policy policy = Policy.builder()
+                    .view(i * 10) // 10, 20, ..., 100
+                    .policyNum("policy" + i)
+                    .title("title" + i)
+                    .region(SEOUL)
+                    .institutionType(LOCAL)
+                    .repeatCode(PERIOD)
+                    .marriage(SINGLE)
+                    .build();
+
+            policyRepository.save(policy);
+        }
+
+        // when
+        List<Policy> top5 = policyRepository.findTop5ByOrderByViewDesc();
+
+        // then
+        assertThat(top5.size()).isEqualTo(5); // 크기 검증 (최대 5개)
+        assertThat(top5)
+                .extracting(Policy::getView)
+                .containsExactly(100L, 90L, 80L, 70L, 60L); // 순서 및 값 검증
+    }
+}

--- a/src/test/java/com/server/youthtalktalk/service/policy/PolicyServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/policy/PolicyServiceTest.java
@@ -1,0 +1,124 @@
+package com.server.youthtalktalk.service.policy;
+
+import static com.server.youthtalktalk.domain.ItemType.POST;
+import static com.server.youthtalktalk.domain.member.entity.Role.*;
+import static com.server.youthtalktalk.domain.policy.entity.InstitutionType.LOCAL;
+import static com.server.youthtalktalk.domain.policy.entity.RepeatCode.PERIOD;
+import static com.server.youthtalktalk.domain.policy.entity.condition.Marriage.SINGLE;
+import static com.server.youthtalktalk.domain.policy.entity.region.Region.SEOUL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.server.youthtalktalk.domain.ItemType;
+import com.server.youthtalktalk.domain.comment.entity.PostComment;
+import com.server.youthtalktalk.domain.member.entity.Member;
+import com.server.youthtalktalk.domain.policy.dto.PolicyWithReviewsDto;
+import com.server.youthtalktalk.domain.policy.dto.ReviewInPolicyDto;
+import com.server.youthtalktalk.domain.policy.entity.Department;
+import com.server.youthtalktalk.domain.policy.entity.Policy;
+import com.server.youthtalktalk.domain.policy.repository.PolicyQueryRepository;
+import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
+import com.server.youthtalktalk.domain.policy.service.PolicyService;
+import com.server.youthtalktalk.domain.policy.service.PolicyServiceImpl;
+import com.server.youthtalktalk.domain.post.entity.Post;
+import com.server.youthtalktalk.domain.post.entity.Review;
+import com.server.youthtalktalk.domain.post.repostiory.PostRepository;
+import com.server.youthtalktalk.domain.post.repostiory.PostRepositoryCustom;
+import com.server.youthtalktalk.domain.post.repostiory.PostRepositoryCustomImpl;
+import com.server.youthtalktalk.domain.scrap.repository.ScrapRepository;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class PolicyServiceTest {
+
+    @Mock
+    private PolicyRepository policyRepository;
+
+    @Mock
+    private PostRepositoryCustomImpl postRepository;
+
+    @Mock
+    private ScrapRepository scrapRepository;
+
+    @InjectMocks
+    private PolicyServiceImpl policyService;
+
+    private final Member member = Member.builder().role(USER).build();
+
+    @Test
+    @DisplayName("인기 정책 5개와 각각의 인기 후기글 3개, 스크랩 수를 포함한 DTO를 반환한다.")
+    void testGetTop5PoliciesWithReviews() {
+        // given
+        // 1. 조회수가 서로 다른 정책 5개 mock
+        Department dept = Department.builder().code("0000000").name("deptName").image_url("image.png").build();
+
+        List<Policy> policies = IntStream.rangeClosed(1, 5)
+                .mapToObj(i -> Policy.builder()
+                        .policyId((long) i)
+                        .view(i * 10L) // 10, 20, ..., 50
+                        .title("title" + i)
+                        .department(dept)
+                        .build())
+                .sorted(Comparator.comparingLong(Policy::getView).reversed()) // 조회수 내림차순으로 정렬
+                .toList();
+
+        when(policyRepository.findTop5ByOrderByViewDesc()).thenReturn(policies);
+
+        // 2. 각 정책에 대한 리뷰 3개씩 mock
+        for (Policy policy : policies) {
+            List<Post> reviews = IntStream.rangeClosed(1, 3)
+                    .mapToObj(j -> {
+                        Post review = mock(Post.class);
+                        when(review.getId()).thenReturn(policy.getPolicyId() * 100 + j);
+                        when(review.getTitle()).thenReturn("Review " + j);
+                        when(review.getContent()).thenReturn("후기내용".repeat(20));
+                        when(review.getPostComments()).thenReturn(List.of(new PostComment(review), new PostComment(review)));
+                        when(review.getCreatedAt()).thenReturn(LocalDateTime.now());
+                        return review;
+                    })
+                    .toList();
+
+            when(postRepository.findTopReviewsByPolicy(member, policy, 3)).thenReturn(reviews);
+
+            // 3. 각 리뷰에 대한 스크랩 수
+            for (Post review : reviews) {
+                when(scrapRepository.countByItemIdAndItemType(review.getId(), POST)).thenReturn(5);
+            }
+        }
+
+        // when
+        List<PolicyWithReviewsDto> result = policyService.getTop5PoliciesWithReviews(member);
+
+        // then
+        assertThat(result).hasSize(5); // 정책 5개
+        for (int i = 0; i < result.size(); i++) {
+            PolicyWithReviewsDto dto = result.get(i);
+            assertThat(dto.policyId()).isEqualTo(policies.get(i).getPolicyId());
+            assertThat(dto.title()).isEqualTo(policies.get(i).getTitle());
+            assertThat(dto.imgUrl()).isEqualTo(policies.get(i).getDepartment().getImage_url());
+            assertThat(dto.reviews()).hasSize(3); // 정책별 후기 3개
+            for (ReviewInPolicyDto review : dto.reviews()) {
+                assertThat(review.scrapCount()).isEqualTo(5);
+                assertThat(review.commentCount()).isEqualTo(2);
+                assertThat(review.contentPreview()).endsWith("...");
+            }
+        }
+
+    }
+}

--- a/src/test/java/com/server/youthtalktalk/service/policy/PolicyServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/policy/PolicyServiceTest.java
@@ -85,7 +85,7 @@ public class PolicyServiceTest {
             List<Post> reviews = IntStream.rangeClosed(1, 3)
                     .mapToObj(j -> {
                         Post review = mock(Post.class);
-                        when(review.getId()).thenReturn(policy.getPolicyId() * 100 + j);
+                        when(review.getId()).thenReturn(policy.getPolicyId() * 100 + (long) j);
                         when(review.getTitle()).thenReturn("Review " + j);
                         when(review.getContent()).thenReturn("후기내용".repeat(20));
                         when(review.getPostComments()).thenReturn(List.of(new PostComment(review), new PostComment(review)));
@@ -98,7 +98,7 @@ public class PolicyServiceTest {
 
             // 3. 각 리뷰에 대한 스크랩 수
             for (Post review : reviews) {
-                when(scrapRepository.countByItemIdAndItemType(review.getId(), POST)).thenReturn(5);
+                when(scrapRepository.countByItemTypeAndItemId(POST, review.getId())).thenReturn(5L);
             }
         }
 
@@ -114,8 +114,8 @@ public class PolicyServiceTest {
             assertThat(dto.imgUrl()).isEqualTo(policies.get(i).getDepartment().getImage_url());
             assertThat(dto.reviews()).hasSize(3); // 정책별 후기 3개
             for (ReviewInPolicyDto review : dto.reviews()) {
-                assertThat(review.scrapCount()).isEqualTo(5);
-                assertThat(review.commentCount()).isEqualTo(2);
+                assertThat(review.scrapCount()).isEqualTo(5L);
+                assertThat(review.commentCount()).isEqualTo(2L);
                 assertThat(review.contentPreview()).endsWith("...");
             }
         }


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #36 

### ⛳ 작업 분류
- [x] 정책과 리뷰를 함께 보내기 위한 dto 생성 
- [x] policy, post, scrap 레포지토리에 필요한 메서드 추가
- [x] 서비스, 컨트롤러 계층의 메서드 구현
- [x] 테스트 코드 구현 및 검증 

### 🔨 작업 상세 내용
1. dto 생성
정책별로 후기글 목록을 포함해서 반환하도록 dto 생성했습니다.

2. 레포지토리 메서드 추가
정책, 게시글, 스크랩 등 여러 도메인에서 검색이 필요해서 레포지토리 계층의 메서드가 다수 추가되었습니다.

   - (지역 무관) 조회수 상위 5개 정책 조회
   - 특정 정책의 후기글 중 인기 있는 게시글 조회
   - 특정 게시글(또는 정책)의 전체 스크랩 수 조회
   
3. 테스트 코드 관련
실제 포스트맨으로 테스트하려면 정책, 후기글, 스크랩 등 여러 도메인 데이터를 미리 생성해야 하고 관계도 복잡하기 때문에, 최대한 테스트 코드 내에서 주요 검증이 가능하도록 신경 써서 구현했습니다.

### 📍 참고 사항
- 특정 정책의 인기 후기글을 조회할 때, 기존에 은혜님께서 구현하신 차단/신고된 게시글을 제외하는 메서드를 재사용했습니다. 해당 과정에서 문제가 없는지 확인 부탁드립니다.
- 엣지 케이스(후기가 없는 경우, 스크랩 수가 없는 경우, 댓글이 없는 경우, 정책이 5개 미만인 경우 등)가 많은데, 이 부분은 프론트분들과 논의하면서 보완하겠습니다.