### PR TITLE
[FEAT] 변경된 디자인에 맞게 정책 조회 API 수정

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/policy/controller/PolicyController.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/controller/PolicyController.java
@@ -1,12 +1,13 @@
 package com.server.youthtalktalk.domain.policy.controller;
 
-import com.server.youthtalktalk.domain.policy.entity.Category;
+import com.server.youthtalktalk.domain.member.service.MemberService;
 import com.server.youthtalktalk.domain.policy.dto.*;
+import com.server.youthtalktalk.domain.policy.entity.Category;
 import com.server.youthtalktalk.domain.policy.entity.SortOption;
+import com.server.youthtalktalk.domain.policy.entity.region.Region;
+import com.server.youthtalktalk.domain.policy.service.PolicyService;
 import com.server.youthtalktalk.global.response.BaseResponse;
 import com.server.youthtalktalk.global.response.BaseResponseCode;
-import com.server.youthtalktalk.domain.member.service.MemberService;
-import com.server.youthtalktalk.domain.policy.service.PolicyService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -26,18 +27,17 @@ public class PolicyController {
     private final MemberService memberService;
 
     /**
-     * 홈 화면 정책 조회 (top5 + allByCategory)
+     * 홈 화면 정책 조회 (우리 지역 인기 정책 + 따끈따끈 새로운 정책)
      */
     @GetMapping("/policies")
-    public BaseResponse<Map<String, List<PolicyListResponseDto>>> getTop5AndCategoryPolicies(@RequestParam List<Category> categories,
-                                                                                             @PageableDefault(size = 10) Pageable pageable) {
-
-        List<PolicyListResponseDto> top5Policies = policyService.getTop5Policies();
-        List<PolicyListResponseDto> allPolicies = policyService.getPoliciesByCategories(categories, pageable);
+    public BaseResponse<Map<String, List<PolicyListResponseDto>>> getTop5AndCategoryPolicies(@RequestParam List<Region> regions,
+                                                                                             @RequestParam List<Category> categories) {
+        List<PolicyListResponseDto> top20Policies = policyService.getTop20Policies(regions);
+        List<PolicyListResponseDto> newPolicies = policyService.getNewPoliciesByCategories(regions, categories);
 
         Map<String, List<PolicyListResponseDto>> responseMap = new LinkedHashMap<>();
-        responseMap.put("top5Policies", top5Policies);
-        responseMap.put("allPolicies", allPolicies);
+        responseMap.put("top20Policies", top20Policies);
+        responseMap.put("newPolicies", newPolicies);
 
         return new BaseResponse<>(responseMap, BaseResponseCode.SUCCESS_POLICY_FOUND);
     }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/controller/PolicyController.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/controller/PolicyController.java
@@ -30,8 +30,8 @@ public class PolicyController {
      * 홈 화면 정책 조회 (우리 지역 인기 정책 + 따끈따끈 새로운 정책)
      */
     @GetMapping("/policies")
-    public BaseResponse<Map<String, List<PolicyListResponseDto>>> getTop5AndCategoryPolicies(@RequestParam List<Region> regions,
-                                                                                             @RequestParam List<Category> categories) {
+    public BaseResponse<Map<String, List<PolicyListResponseDto>>> getTop5AndCategoryPolicies(@RequestParam(required = false) List<Region> regions,
+                                                                                             @RequestParam(required = false) List<Category> categories) {
         List<PolicyListResponseDto> top20Policies = policyService.getTop20Policies(regions);
         List<PolicyListResponseDto> newPolicies = policyService.getNewPoliciesByCategories(regions, categories);
 

--- a/src/main/java/com/server/youthtalktalk/domain/policy/controller/PolicyController.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/controller/PolicyController.java
@@ -30,7 +30,7 @@ public class PolicyController {
      * 홈 화면 정책 조회 (우리 지역 인기 정책 + 따끈따끈 새로운 정책)
      */
     @GetMapping("/policies")
-    public BaseResponse<Map<String, List<PolicyListResponseDto>>> getTop5AndCategoryPolicies(@RequestParam(required = false) List<Region> regions,
+    public BaseResponse<Map<String, List<PolicyListResponseDto>>> getHomePolicies(@RequestParam(required = false) List<Region> regions,
                                                                                              @RequestParam(required = false) List<Category> categories) {
         List<PolicyListResponseDto> top20Policies = policyService.getTop20Policies(regions);
         List<PolicyListResponseDto> newPolicies = policyService.getNewPoliciesByCategories(regions, categories);

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/PolicyDetailResponseDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/PolicyDetailResponseDto.java
@@ -1,69 +1,134 @@
 package com.server.youthtalktalk.domain.policy.dto;
 
 import com.server.youthtalktalk.domain.policy.entity.Policy;
+import com.server.youthtalktalk.domain.policy.entity.condition.Education;
+import com.server.youthtalktalk.domain.policy.entity.condition.Major;
+import com.server.youthtalktalk.domain.policy.entity.condition.Specialization;
+import com.server.youthtalktalk.domain.policy.entity.condition.Employment;
 import lombok.Builder;
 import lombok.Getter;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
 public class PolicyDetailResponseDto {
+    private String departmentImgUrl; // 중앙 부처 이미지
+    private Boolean isScrap;// 스크랩 여부
+    private String recruitmentType; // 모집 상태
     private String title; // 정책명
-    private String introduction; // 정책 소개
-    private String supportDetail; // 지원 내용
-    private String applyTerm; // 신청기간
-    private String operationTerm; // 운영기간
+    private String region; // 지역
+    private String category; // 정책 분야
+    private String hostDep; // 주관 부처명 (주관 기관)
+    private String applyTerm; // 신청 기간
+    private String introduction; // 정책 요약
     private String age; // 연령
-    private String addrIncome; // 거주지 및 소득 조건
-    private String education; // 학력 요건
-    private String major; // 전공 요건
-    private String employment; // 취업 상태
-    private String specialization; // 특화 분야
-    private String applLimit; // 참여 제한 대상
+    private String supportDetail; // 지원 내용
     private String addition; // 추가 사항
+    private String applLimit; // 참여 제한 대상
     private String applStep; // 신청 절차
-    private String evaluation; // 심사 발표
-    private String applUrl; // 신청 사이트
     private String submitDoc; // 제출 서류
-    private String etc; // 기타 사항
-    private String hostDep; // 주관 부처명
-    private String operatingOrg; // 운영 기관명
+    private String evaluation; // 평가 방법
+    private String applUrl; // 신청 사이트
     private String refUrl1; // 참고 사이트 1
     private String refUrl2; // 참고 사이트 2
-    private String formattedApplUrl; // 신청 사이트 (전처리)
-    private Boolean isScrap;// 스크랩 여부
-    private String departmentImgUrl; // 중앙 부처 이미지
-//    private Region region; // 지역
-//    private Category category; // 카테고리
-//    private LocalDate applyDue; // 신청 마감일
-//    private String employmentCode; // 취업 상태 코드 리스트
+    private String etc; // 기타 사항
+    private String subRegion; // 세부 지역
+    private String earnEtc; // 소득 요건
+    private String specialization; // 특화 분야
+    private String major; // 전공 요건
+    private String education; // 학력 요건
+    private String marriage; // 결혼 요건
+    private String employment; // 취업 요건
 
     public static PolicyDetailResponseDto toDto(Policy policy, Boolean isScrap) {
+        // 신청 기간 날짜 포맷팅
+        String applyTerm = formatApplyTerm(policy.getApplyStart(), policy.getApplyDue());
+
+        // 모집 상태 ( 상시 모집 / 모집 마감 / D-000 / 마감 임박 으로 구분 ) - 공고의 마감일이 D-7 이하로 남을 경우에 마감 임박
+        String recruitmentType = getRecruitmentType(policy.getApplyDue());
+
         return PolicyDetailResponseDto.builder()
-                .title(policy.getTitle()) // 정책명
-                .introduction(policy.getIntroduction()) // 정책 소개
-                .supportDetail(policy.getSupportDetail()) // 지원 내용
-                .applyTerm(policy.getApplyTerm()) // 신청기간
-                .operationTerm(null) // 운영기간
-                .age("만 "+ policy.getMinAge() + "세 ~ 만 " + policy.getMaxAge() + "세") // 연령
-                .addrIncome(null) // 거주지 및 소득 조건
-                .education(null) // 학력 요건
-                .major(null) // 전공 요건
-                .employment(null) // 취업 상태
-                .specialization(null) // 특화 분야
-                .applLimit(policy.getApplLimit()) // 참여 제한 대상
-                .addition(policy.getAddition()) // 추가 사항
-                .applStep(policy.getApplStep()) // 신청 절차
-                .evaluation(policy.getEvaluation()) // 심사 발표
-                .applUrl(policy.getApplUrl()) // 신청 사이트
-                .submitDoc(policy.getSubmitDoc()) // 제출 서류
-                .etc(policy.getEtc()) // 기타 사항
-                .hostDep(policy.getHostDep()) // 주관 부처명
-                .operatingOrg(policy.getOperatingOrg()) // 운영 기관명
-                .refUrl1(policy.getRefUrl1()) // 참고 사이트 1
-                .refUrl2(policy.getRefUrl2()) // 참고 사이트 2
-                .formattedApplUrl(null) // 신청 사이트 (전처리)
-                .isScrap(isScrap)// 스크랩 여부
                 .departmentImgUrl(policy.getDepartment().getImage_url()) // 중앙부처 이미지 url
+                .isScrap(isScrap)// 스크랩 여부
+                .recruitmentType(recruitmentType) // 모집 상태
+                .title(policy.getTitle()) // 정책명
+                .region(policy.getRegion().getName()) // 지역
+                .category(policy.getCategory().getName()) // 정책 분야
+                .hostDep(policy.getHostDep()) // 주관 부처명 (주관 기관)
+                .applyTerm(applyTerm) // 신청 기간
+                .introduction(policy.getIntroduction()) // 정책 요약
+                .age("만 "+ policy.getMinAge() + "세 ~ 만 " + policy.getMaxAge() + "세") // 연령
+                .supportDetail(policy.getSupportDetail()) // 지원 내용
+                .addition(sanitize(policy.getAddition())) // 추가 사항
+                .applLimit(sanitize(policy.getApplLimit())) // 참여 제한 대상
+                .applStep(sanitize(policy.getApplStep())) // 신청 절차
+                .submitDoc(sanitize(policy.getSubmitDoc())) // 제출 서류
+                .evaluation(sanitize(policy.getEvaluation())) // 평가 방법
+                .applUrl(sanitize(policy.getApplUrl())) // 신청 사이트
+                .refUrl1(sanitize(policy.getRefUrl1())) // 참고 사이트 1
+                .refUrl2(sanitize(policy.getRefUrl2())) // 참고 사이트 2
+                .etc(sanitize(policy.getEtc())) // 기타 사항
+                .subRegion(sanitize(
+                        policy.getPolicySubRegions().stream()
+                                .map(psr -> psr.getSubRegion().getName())
+                                .collect(Collectors.joining(", "))
+                )) // 세부 지역 (, 로 연결)
+                .earnEtc(sanitize(policy.getEarnEtc())) // 소득 요건
+                .specialization(sanitize(
+                        policy.getSpecialization() == null ? null :
+                                policy.getSpecialization().stream()
+                                        .map(Specialization::getName)
+                                        .collect(Collectors.joining(", "))
+                )) // 특화 분야
+                .major(sanitize(
+                        policy.getMajor() == null ? null :
+                                policy.getMajor().stream()
+                                        .map(Major::getName)
+                                        .collect(Collectors.joining(", "))
+                )) // 전공 요건
+                .education(sanitize(
+                        policy.getEducation() == null ? null :
+                                policy.getEducation().stream()
+                                        .map(Education::getName)
+                                        .collect(Collectors.joining(", "))
+                )) // 학력 요건
+                .marriage(sanitize(policy.getMarriage().getName())) // 결혼 요건
+                .employment(sanitize(
+                        policy.getEmployment() == null ? null :
+                                policy.getEmployment().stream()
+                                        .map(Employment::getName)
+                                        .collect(Collectors.joining(", "))
+                )) // 취업 요건
                 .build();
     }
+
+    private static String sanitize(String value) {
+        if (value == null) return null;
+        if (value.trim().equals("-") || value.trim().equals("제한없음") || value.trim().equals("없음") || value.trim().isEmpty()) {
+            return null;
+        }
+        return value;
+    }
+
+    private static String getRecruitmentType(LocalDate dueDate) {
+        if (dueDate == null) return "상시 모집";
+
+        long daysLeft = ChronoUnit.DAYS.between(LocalDate.now(), dueDate);
+
+        if (daysLeft < 0) return "모집 마감";
+        if (daysLeft <= 7) return "마감 임박";
+        return "D-" + daysLeft;
+    }
+
+    private static String formatApplyTerm(LocalDate start, LocalDate end) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        if (start == null || end == null) {
+            return "상시";
+        }
+        return start.format(formatter) + " ~ " + end.format(formatter);
+    }
+
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/PolicyListResponseDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/PolicyListResponseDto.java
@@ -16,9 +16,10 @@ public class PolicyListResponseDto {
     private String deadlineStatus; // 마감 상태
     private String hostDep; // 주관 기관명
     private boolean isScrap; // 스크랩 여부
+    private long scrapCount; // 스크랩 수
     private String departmentImgUrl; // 중앙부처 이미지 url
 
-    public static PolicyListResponseDto toListDto(Policy policy, Boolean isScrap) {
+    public static PolicyListResponseDto toListDto(Policy policy, Boolean isScrap, long scrapCount) {
         return PolicyListResponseDto.builder()
                 .policyId(policy.getPolicyId())
                 .category(policy.getCategory())
@@ -26,6 +27,7 @@ public class PolicyListResponseDto {
                 .deadlineStatus(DeadlineStatusCalculator.calculateDeadline(policy.getApplyDue()))
                 .hostDep(policy.getHostDep())
                 .isScrap(isScrap)
+                .scrapCount(scrapCount)
                 .departmentImgUrl(policy.getDepartment().getImage_url())
                 .build();
     }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/Policy.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/Policy.java
@@ -105,7 +105,7 @@ public class Policy extends BaseTimeEntity {
 
     /** 신규 필드 */
     @Column(name = "is_limited_age")
-    private Boolean isLimitedAge;
+    private Boolean isLimitedAge; // 지원 대상 연령 제한 여부
 
     @Enumerated(EnumType.STRING)
     @Column(name = "earn", length = 20)
@@ -121,7 +121,7 @@ public class Policy extends BaseTimeEntity {
     private String earnEtc; // 소득 기타 내용
 
     @Column(name = "zip_cd", columnDefinition = "TEXT")
-    private String zipCd;
+    private String zipCd; // 정책 거주 지역 코드
 
     @ElementCollection
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyService.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyService.java
@@ -1,6 +1,7 @@
 package com.server.youthtalktalk.domain.policy.service;
 
 import com.server.youthtalktalk.domain.policy.entity.SortOption;
+import com.server.youthtalktalk.domain.policy.entity.region.Region;
 import com.server.youthtalktalk.domain.scrap.entity.Scrap;
 import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.policy.entity.Category;
@@ -10,8 +11,9 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface PolicyService {
-    List<PolicyListResponseDto> getTop5Policies();
+    List<PolicyListResponseDto> getTop20Policies(List<Region> regions);
     List<PolicyListResponseDto> getPoliciesByCategories(List<Category> categories, Pageable pageable);
+    List<PolicyListResponseDto> getNewPoliciesByCategories(List<Region> regions, List<Category> categories);
     SearchConditionResponseDto getPoliciesByCondition(SearchConditionRequestDto condition, Pageable pageable, SortOption sortOption);
     List<SearchNameResponseDto> getPoliciesByName(String title, Pageable pageable);
     PolicyDetailResponseDto getPolicyDetail(Long policyId);

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
@@ -79,8 +79,9 @@ public class PolicyServiceImpl implements PolicyService {
 
         List<PolicyListResponseDto> result = policies.stream()
                 .map(policy -> {
+                    long scrapCount = scrapRepository.countByItemTypeAndItemId(ItemType.POLICY, policy.getPolicyId());
                     boolean isScrap = scrapRepository.existsByMemberIdAndItemIdAndItemType(memberId, policy.getPolicyId(), ItemType.POLICY);
-                    return PolicyListResponseDto.toListDto(policy, isScrap);
+                    return PolicyListResponseDto.toListDto(policy, isScrap, scrapCount);
                 })
                 .collect(Collectors.toList());
 
@@ -109,8 +110,9 @@ public class PolicyServiceImpl implements PolicyService {
         }
         List<PolicyListResponseDto> result =  policies.stream()
                 .map(policy -> {
+                    long scrapCount = scrapRepository.countByItemTypeAndItemId(ItemType.POLICY, policy.getPolicyId());
                     boolean isScrap = scrapRepository.existsByMemberIdAndItemIdAndItemType(memberId, policy.getPolicyId(), ItemType.POLICY);
-                    return PolicyListResponseDto.toListDto(policy, isScrap);
+                    return PolicyListResponseDto.toListDto(policy, isScrap, scrapCount);
                 })
                 .collect(Collectors.toList());
         log.info("카테고리별 정책 조회 성공");
@@ -150,8 +152,9 @@ public class PolicyServiceImpl implements PolicyService {
 
         return policies.stream()
                 .map(policy -> {
+                    long scrapCount = scrapRepository.countByItemTypeAndItemId(ItemType.POLICY, policy.getPolicyId());
                     boolean isScrap = scrapRepository.existsByMemberIdAndItemIdAndItemType(memberId, policy.getPolicyId(), ItemType.POLICY);
-                    return PolicyListResponseDto.toListDto(policy, isScrap);
+                    return PolicyListResponseDto.toListDto(policy, isScrap, scrapCount);
                 })
                 .collect(Collectors.toList());
     }
@@ -194,9 +197,10 @@ public class PolicyServiceImpl implements PolicyService {
 
         List<PolicyListResponseDto> result = policies.stream()
                 .map(policy -> {
+                    long scrapCount = scrapRepository.countByItemTypeAndItemId(ItemType.POLICY, policy.getPolicyId());
                     boolean isScrap = scrapRepository.existsByMemberIdAndItemIdAndItemType(
                             memberService.getCurrentMember().getId(), policy.getPolicyId(), ItemType.POLICY);
-                    return PolicyListResponseDto.toListDto(policy, isScrap);
+                    return PolicyListResponseDto.toListDto(policy, isScrap, scrapCount);
                 })
                 .collect(Collectors.toList());
         log.info("조건 적용 정책 조회 성공");
@@ -451,8 +455,9 @@ public class PolicyServiceImpl implements PolicyService {
         List<Policy> policies = policyRepository.findAllByScrap(member, pageRequest).getContent();
         return policies.stream()
                 .map(policy -> {
+                    long scrapCount = scrapRepository.countByItemTypeAndItemId(ItemType.POLICY, policy.getPolicyId());
                     boolean isScrap = true;
-                    return PolicyListResponseDto.toListDto(policy, isScrap);
+                    return PolicyListResponseDto.toListDto(policy, isScrap, scrapCount);
                 })
                 .collect(Collectors.toList());
     }
@@ -466,8 +471,9 @@ public class PolicyServiceImpl implements PolicyService {
         List<Policy> policies = policyRepository.findTop5OrderByDeadlineAsc(member, pageRequest).getContent();
         return policies.stream()
                 .map(policy -> {
+                    long scrapCount = scrapRepository.countByItemTypeAndItemId(ItemType.POLICY, policy.getPolicyId());
                     boolean isScrap = true;
-                    return PolicyListResponseDto.toListDto(policy, isScrap);
+                    return PolicyListResponseDto.toListDto(policy, isScrap, scrapCount);
                 })
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
@@ -1,32 +1,23 @@
 package com.server.youthtalktalk.domain.policy.service;
 
 import com.server.youthtalktalk.domain.ItemType;
-import com.server.youthtalktalk.domain.policy.dto.SearchConditionDto;
-import com.server.youthtalktalk.domain.policy.entity.InstitutionType;
-import com.server.youthtalktalk.domain.policy.entity.SortOption;
-import com.server.youthtalktalk.domain.policy.entity.condition.Education;
-import com.server.youthtalktalk.domain.policy.entity.condition.Employment;
-import com.server.youthtalktalk.domain.policy.entity.condition.Major;
-import com.server.youthtalktalk.domain.policy.entity.condition.Marriage;
-import com.server.youthtalktalk.domain.policy.entity.condition.Specialization;
-import com.server.youthtalktalk.domain.policy.entity.region.SubRegion;
-import com.server.youthtalktalk.domain.policy.repository.region.SubRegionRepository;
-import com.server.youthtalktalk.domain.scrap.entity.Scrap;
 import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.member.service.MemberService;
 import com.server.youthtalktalk.domain.policy.dto.*;
 import com.server.youthtalktalk.domain.policy.entity.Category;
+import com.server.youthtalktalk.domain.policy.entity.InstitutionType;
 import com.server.youthtalktalk.domain.policy.entity.Policy;
+import com.server.youthtalktalk.domain.policy.entity.SortOption;
+import com.server.youthtalktalk.domain.policy.entity.condition.*;
 import com.server.youthtalktalk.domain.policy.entity.region.Region;
+import com.server.youthtalktalk.domain.policy.entity.region.SubRegion;
 import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
+import com.server.youthtalktalk.domain.policy.repository.region.SubRegionRepository;
+import com.server.youthtalktalk.domain.scrap.entity.Scrap;
 import com.server.youthtalktalk.domain.scrap.repository.ScrapRepository;
-import com.server.youthtalktalk.global.response.BaseResponseCode;
 import com.server.youthtalktalk.global.response.exception.InvalidValueException;
 import com.server.youthtalktalk.global.response.exception.member.MemberNotFoundException;
 import com.server.youthtalktalk.global.response.exception.policy.PolicyNotFoundException;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -35,6 +26,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -61,19 +56,24 @@ public class PolicyServiceImpl implements PolicyService {
      * top 5 정책 조회
      */
     @Override
-    public List<PolicyListResponseDto> getTop5Policies() {
+    public List<PolicyListResponseDto> getTop20Policies(List<Region> regions) {
         Long memberId;
-        Region region;
         try {
             memberId = memberService.getCurrentMember().getId();
-            region = memberService.getCurrentMember().getRegion();
         } catch (Exception e) {
             throw new MemberNotFoundException();
         }
 
-        PageRequest pageRequest = PageRequest.of(0, 5); // top 5
-        List<Policy> policies = policyRepository.findTop5ByRegionOrderByViewsDesc(region, pageRequest).getContent();
-        if (policies.isEmpty()) {
+        PageRequest pageRequest = PageRequest.of(0, 20); // top 20
+
+        List<Policy> policies;
+        if (regions== null){
+            policies = policyRepository.findTop20OrderByViewsDesc(pageRequest).getContent();
+        } else{
+            policies = policyRepository.findTop20ByRegionsOrderByViewsDesc(regions, pageRequest).getContent();
+        }
+
+        if(policies.isEmpty()){
             throw new PolicyNotFoundException();
         }
 
@@ -83,7 +83,8 @@ public class PolicyServiceImpl implements PolicyService {
                     return PolicyListResponseDto.toListDto(policy, isScrap);
                 })
                 .collect(Collectors.toList());
-        log.info("상위 5개 정책 조회 성공");
+
+        log.info("상위 20개 정책 조회 성공");
         return result;
     }
 
@@ -114,6 +115,45 @@ public class PolicyServiceImpl implements PolicyService {
                 .collect(Collectors.toList());
         log.info("카테고리별 정책 조회 성공");
         return result;
+    }
+
+
+    /**
+     * 카테고리 별 새로운 정책 조회 (최근 7일 기준)
+     */
+    @Override
+    public List<PolicyListResponseDto> getNewPoliciesByCategories(List<Region> regions, List<Category> categories) {
+        Long memberId;
+        try {
+            memberId = memberService.getCurrentMember().getId();
+        } catch (Exception e) {
+            throw new MemberNotFoundException();
+        }
+
+        LocalDate today = LocalDate.now(); // 오늘 날짜
+        LocalDate fromDate = today.minusDays(6); // 일주일 전 날짜
+        LocalDateTime fromDateTime = fromDate.atStartOfDay(); // 일주일 전 0시
+        LocalDateTime toDateTime = today.plusDays(1).atStartOfDay(); // 오늘 24시
+
+        PageRequest pageRequest = PageRequest.of(0, 20); // 20개 제한
+
+        List<Policy> policies;
+        if (regions== null) {
+            policies = policyRepository
+                    .findRecentPoliciesAndCategory(categories, fromDateTime, toDateTime, pageRequest)
+                    .getContent();
+        }else {
+            policies = policyRepository
+                    .findRecentPoliciesByRegionAndCategory(regions, categories, fromDateTime, toDateTime, pageRequest)
+                    .getContent();
+        }
+
+        return policies.stream()
+                .map(policy -> {
+                    boolean isScrap = scrapRepository.existsByMemberIdAndItemIdAndItemType(memberId, policy.getPolicyId(), ItemType.POLICY);
+                    return PolicyListResponseDto.toListDto(policy, isScrap);
+                })
+                .collect(Collectors.toList());
     }
 
 

--- a/src/main/java/com/server/youthtalktalk/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/scrap/repository/ScrapRepository.java
@@ -16,4 +16,7 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     Optional<Scrap> findByMemberAndItemIdAndItemType(Member memberId, Long itemId, ItemType itemType);
     List<Scrap> findAllByItemIdAndItemType(Long itemId, ItemType itemType);
     void deleteAllByItemIdAndItemType(Long itemId, ItemType itemType);
+
+    long countByItemTypeAndItemId(ItemType itemType, Long itemId);
+
 }


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #38

### ⛳ 작업 분류
- [x] 변경된 디자인에 맞게 정책 세부 조회 API 수정
- [x] 변경된 디자인에 맞게 홈 화면 정책 조회 API 수정
- [x] 기존 PolicyListResponseDto에 스크랩 수 추가

### 🔨 작업 상세 내용
1. 정책 세부 조회에서, 리스트 필드는 내부 값들을 ", "로 연결하여 하나의 String으로 반환합니다.
2. 정책 세부 조회에서, 기 논의한 대로 의미없는 필드는 null 처리하였습니다.
3. 홈 화면 조회에서, 정책과 커뮤니티는 분리하는 게 좋을 것 같아 기존 홈 화면 정책 조회 API를 "우리 지역 인기 정책 + 따끈따끈 새로운 정책"을 응답하는 것으로 수정했습니다.
4. 홈 화면 조회에서, 모든 지역 선택하면 프론트에서 null로 요청받고, 지역 자체에 필터링을 아예 안 거는 방식으로 해결했습니다. (지역 필터링 걸어야 하는 경우 요청 들어온 지역 + ALL로 필터링합니다.)

### 📍 참고 사항
- 로컬에서 테스트해보고 작동 잘 되는 것을 확인하였습니다.
- 포스트맨 명세서 업데이트했습니다.
