### PR TITLE
[FEAT] 자유게시글, 리뷰 조회 시 내용 미리보기 추가, 실시간 정책 조회 API 응답 수정

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/ReviewInPolicyDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/ReviewInPolicyDto.java
@@ -8,6 +8,6 @@ public record ReviewInPolicyDto(
         String contentPreview,
         long commentCount,
         long scrapCount,
-        LocalDate createdAt
+        String createdAt
 ) {
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
@@ -517,14 +517,13 @@ public class PolicyServiceImpl implements PolicyService {
     private ReviewInPolicyDto toReviewInPolicyDto(Post review) {
         // 후기글의 스크랩 수 조회
         long scrapCount = scrapRepository.countByItemTypeAndItemId(POST, review.getId());
-
         return new ReviewInPolicyDto(
                 review.getId(), // 게시글 id
                 review.getTitle(), // 게시글 제목
                 createContentSnippet(review.getContents().get(0).getContent()), // 내용 미리보기
                 review.getPostComments().size(), // 댓글 수
                 scrapCount, // 스크랩 수
-                review.getCreatedAt().toLocalDate() // 작성일
+                review.getCreatedAt().toLocalDate().toString() // 작성일
         );
     }
 

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
@@ -521,7 +521,7 @@ public class PolicyServiceImpl implements PolicyService {
         return new ReviewInPolicyDto(
                 review.getId(), // 게시글 id
                 review.getTitle(), // 게시글 제목
-                createContentSnippet(review.getContent()), // 내용 미리보기
+                createContentSnippet(review.getContents().get(0).getContent()), // 내용 미리보기
                 review.getPostComments().size(), // 댓글 수
                 scrapCount, // 스크랩 수
                 review.getCreatedAt().toLocalDate() // 작성일

--- a/src/main/java/com/server/youthtalktalk/domain/post/dto/PostListRepDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/dto/PostListRepDto.java
@@ -30,6 +30,7 @@ public class PostListRepDto {
         private int comments;
         private Long policyId; // 자유글 null
         private String policyTitle; // 자유글 null
+        private String contentPreview;
     }
 
     @Getter
@@ -44,6 +45,7 @@ public class PostListRepDto {
         private Long policyId; // 자유글 null
         private String policyTitle; // 자유글 null
         private Long scrapId;
+        private String contentPreview;
     }
 
 }

--- a/src/main/java/com/server/youthtalktalk/domain/post/service/PostReadServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/service/PostReadServiceImpl.java
@@ -42,6 +42,7 @@ public class PostReadServiceImpl implements PostReadService {
     private final BlockRepository blockRepository;
     private final PostRepositoryCustom postRepositoryCustom;
     private static final int TOP = 5;
+    private static final int CONTENT_PREVIEW_MAX_LEN = 50;
     /** 게시글, 리뷰 상세 조회 */
     @Override
     @Transactional
@@ -142,6 +143,7 @@ public class PostReadServiceImpl implements PostReadService {
                 .policyId(post instanceof Review ? ((Review) post).getPolicy().getPolicyId() : null)
                 .policyTitle(post instanceof Review ? ((Review)post).getPolicy().getTitle() : null )
                 .comments(post.getPostComments().size())
+                .contentPreview(createContentSnippet(post.getContents().get(0).getContent()))
                 .scrap(scrapRepository.existsByMemberIdAndItemIdAndItemType(member.getId(),post.getId(),ItemType.POST))
                 .scraps(scrapRepository.findAllByItemIdAndItemType(post.getId(), ItemType.POST).size())
                 .build();
@@ -157,9 +159,16 @@ public class PostReadServiceImpl implements PostReadService {
                 .policyId(post instanceof Review ? ((Review) post).getPolicy().getPolicyId() : null)
                 .policyTitle(post instanceof Review ? ((Review)post).getPolicy().getTitle() : null )
                 .comments(post.getPostComments().size())
+                .contentPreview(createContentSnippet(post.getContents().get(0).getContent()))
                 .scrap(true)
                 .scraps(scrapRepository.findAllByItemIdAndItemType(post.getId(), ItemType.POST).size())
                 .scrapId(scrap.getId())
                 .build();
+    }
+
+    private String createContentSnippet(String content) {
+        return content.length() > CONTENT_PREVIEW_MAX_LEN
+                ? content.substring(0, CONTENT_PREVIEW_MAX_LEN) + "..."
+                : content;
     }
 }

--- a/src/test/java/com/server/youthtalktalk/service/policy/PolicyServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/policy/PolicyServiceTest.java
@@ -24,6 +24,8 @@ import com.server.youthtalktalk.domain.policy.repository.PolicyQueryRepository;
 import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
 import com.server.youthtalktalk.domain.policy.service.PolicyService;
 import com.server.youthtalktalk.domain.policy.service.PolicyServiceImpl;
+import com.server.youthtalktalk.domain.post.entity.Content;
+import com.server.youthtalktalk.domain.post.entity.ContentType;
 import com.server.youthtalktalk.domain.post.entity.Post;
 import com.server.youthtalktalk.domain.post.entity.Review;
 import com.server.youthtalktalk.domain.post.repostiory.PostRepository;
@@ -31,6 +33,7 @@ import com.server.youthtalktalk.domain.post.repostiory.PostRepositoryCustom;
 import com.server.youthtalktalk.domain.post.repostiory.PostRepositoryCustomImpl;
 import com.server.youthtalktalk.domain.scrap.repository.ScrapRepository;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -87,7 +90,7 @@ public class PolicyServiceTest {
                         Review review = mock(Review.class);
                         when(review.getId()).thenReturn(policy.getPolicyId() * 100 + (long) j);
                         when(review.getTitle()).thenReturn("Review " + j);
-                        when(review.getContent()).thenReturn("후기내용".repeat(20));
+                        when(review.getContents()).thenReturn(createContent("후기내용".repeat(20)));
                         when(review.getPostComments()).thenReturn(List.of(new PostComment(review), new PostComment(review)));
                         when(review.getCreatedAt()).thenReturn(LocalDateTime.now());
                         return review;
@@ -119,6 +122,12 @@ public class PolicyServiceTest {
                 assertThat(review.contentPreview()).endsWith("...");
             }
         }
+    }
 
+    private List<Content> createContent(String content){
+        return new ArrayList<>(List.of(Content.builder()
+                .content(content)
+                .type(ContentType.TEXT)
+                .build()));
     }
 }


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #34 

### ⛳ 작업 분류
- [x] 자유게시글, 리뷰글 목록 조회 시 내용 미리보기 추가
- [x] 실시간 정책 조회 API 응답값 수정 

### 🔨 작업 상세 내용
1. PostReadServiceImpl : toPostListDto(), toScrapPostListDto()에 글 내용 미리보기 추가(50자까지 자른 후 ... 추가)
2. PolicyServiceImpl : getContent()로 미리보기 가져오는 부분을 getContents().get(0)으로 수정
3. ReviewInPolicyDto : createdAt LocalDate -> String으로 타입 변경
- 포스트맨에서 실시간 정책 조회 시 다음과 같이 날짜가 배열로 분리되는 현상을 발견했습니다.
`"createdAt": [2025, 04, 01]`
- 이를 해결하고자 String으로 타입을 변경하고, LocalDate.toString()으로 반환했습니다.


### 📍 참고 사항
- 현재 게시글 관련 서비스에서는 **content가 아닌 contents로 게시글 본문 내용을 리스트화하여 관리**하고 있습니다. 이는 블로그처럼 글과 글 사이에 사진을 추가하기 위하여 변경된 부분이었습니다.
근데 아직 DB에는 예전에 사용하던 content 필드가 남아있습니다. 
제 기억에 바로 필드 삭제하면 혹시 프론트분들에게 문제가 생길까봐 남겼다가, 이후 프론트분들에게 물어봤을 때 해당 필드는 더 이상 사용하지 않는 것을 답변받고 삭제하기로 결정했던거 같습니다. 해당 필드는 추후 삭제하도록 하겠습니다.
