### PR TITLE
[FEAT] 최근 본 정책 API 구현

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/member/entity/Member.java
+++ b/src/main/java/com/server/youthtalktalk/domain/member/entity/Member.java
@@ -4,6 +4,7 @@ import com.server.youthtalktalk.domain.BaseTimeEntity;
 import com.server.youthtalktalk.domain.image.entity.ProfileImage;
 import com.server.youthtalktalk.domain.likes.entity.Likes;
 import com.server.youthtalktalk.domain.notification.entity.Notification;
+import com.server.youthtalktalk.domain.policy.entity.Policy;
 import com.server.youthtalktalk.domain.report.entity.Report;
 import com.server.youthtalktalk.domain.scrap.entity.Scrap;
 import com.server.youthtalktalk.domain.comment.entity.Comment;
@@ -12,8 +13,7 @@ import com.server.youthtalktalk.domain.post.entity.Post;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 @Entity
 @Getter
@@ -69,6 +69,10 @@ public class Member extends BaseTimeEntity {
     @OneToMany(mappedBy = "receiver", cascade = CascadeType.ALL)
     private List<Notification> notifications = new ArrayList<>();
 
+    @ElementCollection
+    @CollectionTable(name = "recent_viewed_policies")
+    private List<Long> recentViewedPolicies = new LinkedList<>();
+
     @JoinColumn(name = "img_id")
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private ProfileImage profileImage;
@@ -106,6 +110,20 @@ public class Member extends BaseTimeEntity {
     // profileImage 업데이트
     public void updateProfileImage(ProfileImage updateProfileImage) {
         this.profileImage = updateProfileImage;
+    }
+
+    // recentViewedPolicies 정책 추가
+    public void addRecentViewedPolicies(Long policyId) {
+        // 중복인 경우 순서 유지를 위해 기존 값 제거 후 추가
+        if (recentViewedPolicies.contains(policyId)) {
+            recentViewedPolicies.remove(policyId);
+        }
+        recentViewedPolicies.add(policyId);
+
+        // 20개 초과 시 가장 오래된 정책 제거
+        if (recentViewedPolicies.size() > 20) {
+            recentViewedPolicies.remove(0); // 가장 오래된 값 제거
+        }
     }
 
     /* 연관관계 편의 메서드 */

--- a/src/main/java/com/server/youthtalktalk/domain/policy/controller/PolicyController.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/controller/PolicyController.java
@@ -125,4 +125,13 @@ public class PolicyController {
         return new BaseResponse<>(top5PoliciesWithReviews, SUCCESS);
     }
 
+    /**
+     * 최근 본 정책 20개 조회
+     */
+    @GetMapping("/policies/recent-view")
+    public BaseResponse<List<PolicyListResponseDto>> getRecentViewedPolicies() {
+        List<PolicyListResponseDto> recentViewedPolicies = policyService.getRecentViewedPolicies();
+        return new BaseResponse<>(recentViewedPolicies, SUCCESS);
+    }
+
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyRepository.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 
 @Repository
@@ -103,4 +104,10 @@ public interface PolicyRepository extends JpaRepository<Policy,String>, PolicyQu
      * (기본 조회수순, 조회수 같으면 최신순 정렬)
      */
     List<Policy> findTop5ByOrderByViewDescPolicyNumDesc();
+
+    /**
+     * 최근 본 정책 아이디 리스트로 정책 조회
+     */
+    List<Policy> findAllByPolicyIdIn(List<Long> policyIds);
+
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyService.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyService.java
@@ -21,4 +21,5 @@ public interface PolicyService {
     List<PolicyListResponseDto> getScrapPolicies(Pageable pageable,Member member);
     List<PolicyListResponseDto> getScrappedPoliciesWithUpcomingDeadline(Member member);
     List<PolicyWithReviewsDto> getTop5PoliciesWithReviews(Member member);
+    List<PolicyListResponseDto> getRecentViewedPolicies();
 }

--- a/src/test/java/com/server/youthtalktalk/service/policy/PolicyServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/policy/PolicyServiceTest.java
@@ -1,25 +1,32 @@
 package com.server.youthtalktalk.service.policy;
 
+import static com.server.youthtalktalk.domain.ItemType.POLICY;
 import static com.server.youthtalktalk.domain.ItemType.POST;
 import static com.server.youthtalktalk.domain.member.entity.Role.*;
 import static com.server.youthtalktalk.domain.policy.entity.InstitutionType.LOCAL;
 import static com.server.youthtalktalk.domain.policy.entity.RepeatCode.PERIOD;
+import static com.server.youthtalktalk.domain.policy.entity.condition.Marriage.MARRIED;
 import static com.server.youthtalktalk.domain.policy.entity.condition.Marriage.SINGLE;
 import static com.server.youthtalktalk.domain.policy.entity.region.Region.SEOUL;
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.server.youthtalktalk.domain.ItemType;
 import com.server.youthtalktalk.domain.comment.entity.PostComment;
 import com.server.youthtalktalk.domain.member.entity.Member;
+import com.server.youthtalktalk.domain.member.service.MemberService;
+import com.server.youthtalktalk.domain.policy.dto.PolicyListResponseDto;
 import com.server.youthtalktalk.domain.policy.dto.PolicyWithReviewsDto;
 import com.server.youthtalktalk.domain.policy.dto.ReviewInPolicyDto;
+import com.server.youthtalktalk.domain.policy.entity.Category;
 import com.server.youthtalktalk.domain.policy.entity.Department;
+import com.server.youthtalktalk.domain.policy.entity.InstitutionType;
 import com.server.youthtalktalk.domain.policy.entity.Policy;
+import com.server.youthtalktalk.domain.policy.entity.region.Region;
 import com.server.youthtalktalk.domain.policy.repository.PolicyQueryRepository;
 import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
 import com.server.youthtalktalk.domain.policy.service.PolicyService;
@@ -33,9 +40,7 @@ import com.server.youthtalktalk.domain.post.repostiory.PostRepositoryCustom;
 import com.server.youthtalktalk.domain.post.repostiory.PostRepositoryCustomImpl;
 import com.server.youthtalktalk.domain.scrap.repository.ScrapRepository;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 import java.util.stream.IntStream;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -49,6 +54,8 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 public class PolicyServiceTest {
+    @Mock
+    private MemberService memberService;
 
     @Mock
     private PolicyRepository policyRepository;
@@ -63,14 +70,14 @@ public class PolicyServiceTest {
     private PolicyServiceImpl policyService;
 
     private final Member member = Member.builder().role(USER).build();
+    private final Department dept = Department.builder().code("0000000").name("deptName").image_url("image.png").build();
+    private static final long RECENT_VIEW_MAX_LEN = 20;
 
     @Test
     @DisplayName("인기 정책 5개와 각각의 인기 후기글 3개, 스크랩 수를 포함한 DTO를 반환한다.")
     void testGetTop5PoliciesWithReviews() {
         // given
         // 1. 조회수가 서로 다른 정책 5개 mock
-        Department dept = Department.builder().code("0000000").name("deptName").image_url("image.png").build();
-
         List<Policy> policies = IntStream.rangeClosed(1, 5)
                 .mapToObj(i -> Policy.builder()
                         .policyId((long) i)
@@ -121,6 +128,90 @@ public class PolicyServiceTest {
                 assertThat(review.commentCount()).isEqualTo(2L);
                 assertThat(review.contentPreview()).endsWith("...");
             }
+        }
+    }
+
+    @Test
+    @DisplayName("정책 조회 시 최근 본 정책 목록 추가")
+    void successAddRecentViewedPolicies(){
+        // Given
+        List<Long> recentViewedPolicyIds = new ArrayList<>();
+        for(long i = 1; i <= RECENT_VIEW_MAX_LEN; i++){
+            recentViewedPolicyIds.add(i);
+        }
+        Member member = Member.builder().recentViewedPolicies(recentViewedPolicyIds).role(USER).build();
+
+        Policy viewedPolicy = Policy.builder()
+                .policyId(1L)
+                .view(1)
+                .title("title")
+                .region(SEOUL)
+                .category(Category.JOB)
+                .marriage(MARRIED)
+                .institutionType(LOCAL)
+                .department(dept)
+                .build();
+
+        // When
+        when(memberService.getCurrentMember()).thenReturn(member);
+        doReturn(Optional.ofNullable(viewedPolicy)).when(policyRepository).findByPolicyId(1L);
+
+        doReturn(viewedPolicy.toBuilder().view(2).build()).when(policyRepository).save(any());
+        when(scrapRepository.existsByMemberIdAndItemIdAndItemType(member.getId(), viewedPolicy.getPolicyId(), POLICY)).thenReturn(true);
+
+        policyService.getPolicyDetail(viewedPolicy.getPolicyId());
+
+        // Then
+        List<Long> recentViewedPolicies = member.getRecentViewedPolicies();
+        int size = recentViewedPolicies.size();
+        long first = recentViewedPolicies.get(0);
+        long last = recentViewedPolicies.get(size - 1);
+        assertThat(recentViewedPolicies).hasSize((int) RECENT_VIEW_MAX_LEN);
+
+        assertThat(last).isEqualTo(1L); // 새로 추가된 값
+        assertThat(first).isEqualTo(2L); // 최대 사이즈 유지를 위해 가장 오래된 정책은 제거됨
+        // 중복 제거 테스트
+        assertThat(recentViewedPolicies.stream().filter(id -> id.equals(1L)).count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("최근 본 정책 조회 성공")
+    void successGetRecentViewedPolicies(){
+        // Given
+        List<Long> recentViewedPolicyIds = new ArrayList<>();
+        List<Policy> recentViewedPolicies = new ArrayList<>();
+        for(long i = 1; i <= RECENT_VIEW_MAX_LEN; i++){
+            recentViewedPolicyIds.add(i);
+            recentViewedPolicies.add(Policy.builder()
+                            .policyId(i)
+                            .view(1)
+                            .title("title" + i)
+                            .department(dept)
+                            .build());
+        }
+
+        Member member = Member.builder().recentViewedPolicies(recentViewedPolicyIds).role(USER).build();
+
+        // When
+        when(memberService.getCurrentMember()).thenReturn(member);
+        when(policyRepository.findAllByPolicyIdIn(member.getRecentViewedPolicies())).thenReturn(recentViewedPolicies);
+        for (Policy policy : recentViewedPolicies) {
+            when(scrapRepository.countByItemTypeAndItemId(ItemType.POLICY, policy.getPolicyId()))
+                    .thenReturn(1L);
+            when(scrapRepository.existsByMemberIdAndItemIdAndItemType(member.getId(), policy.getPolicyId(), ItemType.POLICY))
+                    .thenReturn(true);
+        }
+
+        List<PolicyListResponseDto> result = policyService.getRecentViewedPolicies();
+        // Then
+        assertThat(result.size()).isEqualTo(RECENT_VIEW_MAX_LEN);
+        for(long i = 0; i < RECENT_VIEW_MAX_LEN; i++){
+            PolicyListResponseDto response = result.get((int)i);
+            Long expectedId = RECENT_VIEW_MAX_LEN - i;
+            assertThat(response.getPolicyId()).isEqualTo(expectedId);
+            assertThat(response.getTitle()).isEqualTo("title" + expectedId);
+            assertThat(response.getScrapCount()).isEqualTo(1L);
+            assertThat(response.isScrap()).isTrue();
         }
     }
 


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #34 

### ⛳ 작업 분류
- [x] 최근 본 정책 API 구현
- [x] 테스트 코드 구현 

### 🔨 작업 상세 내용
1. `List<Long> recentViewedPolicies = new LinkedList<>();` 를 이용하여 최근 본 정책 목록을 `Member엔티티`에서 관리했습니다.
2. `@ElementCollection `이용하여 20개까지만 테이블에 저장하고 있습니다. **Policy 엔티티와 조인할 필요는 없다고 판단했습니다.**
3. 프론트에게는 **총 20개를 한번에 반환합니다.**
4. 최근 본 정책이 총 20개인 상태에서 다른 정책을 조회 시, 본지 가장 오래된 정책을 제거합니다. 또한 중복된 정책 조회 시 기존의 중복 값을 제거하고 새롭게 리스트에 추가했습니다.

### 📍 참고 사항
- 이 부분은 추후 **Redis 캐싱 등을 이용하면 훨씬 효율적으로 구현할 수 있을 거 같습니다.** 
- id값으로 삽입, 삭제가 일어나고 중복 검사를 하기 때문에 `LinkedHashSet`을 이용하려고 했지만, 순서 유지 부분에서 문제를 겪어 일단 List로 구현하였습니다. 이 부분은 개선이 필요합니다.
