### PR TITLE
[FIX] 최근 본 정책 API 20개 -> 10개로 수정

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/member/entity/Member.java
+++ b/src/main/java/com/server/youthtalktalk/domain/member/entity/Member.java
@@ -120,8 +120,8 @@ public class Member extends BaseTimeEntity {
         }
         recentViewedPolicies.add(policyId);
 
-        // 20개 초과 시 가장 오래된 정책 제거
-        if (recentViewedPolicies.size() > 20) {
+        // 10개 초과 시 가장 오래된 정책 제거
+        if (recentViewedPolicies.size() > 10) {
             recentViewedPolicies.remove(0); // 가장 오래된 값 제거
         }
     }

--- a/src/test/java/com/server/youthtalktalk/service/policy/PolicyServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/policy/PolicyServiceTest.java
@@ -71,7 +71,7 @@ public class PolicyServiceTest {
 
     private final Member member = Member.builder().role(USER).build();
     private final Department dept = Department.builder().code("0000000").name("deptName").image_url("image.png").build();
-    private static final long RECENT_VIEW_MAX_LEN = 20;
+    private static final long RECENT_VIEW_MAX_LEN = 10;
 
     @Test
     @DisplayName("인기 정책 5개와 각각의 인기 후기글 3개, 스크랩 수를 포함한 DTO를 반환한다.")


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #34 

### ⛳ 작업 분류
- [x] 최근 본 정책 API에서 최대 저장 개수 20개를 10개로 수정

