### PR TITLE
[FIX] 회원 관심지역 옵션 추가로 인한 관련 API 수정 (회원가입, 회원정보 수정, 홈화면 정책 조회 API)

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/member/dto/MemberUpdateDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/member/dto/MemberUpdateDto.java
@@ -12,7 +12,7 @@ public record MemberUpdateDto(
                 message = "닉네임은 한글과 영어(대소문자) 및 숫자만 가능하며, 공백과 특수문자는 사용할 수 없습니다."
         )
         String nickname,
-        @Pattern(regexp = "서울|부산|대구|인천|광주|대전|울산|경기|강원|충북|충남|전북|전남|경북|경남|제주|세종",
+        @Pattern(regexp = "서울|부산|대구|인천|광주|대전|울산|경기|강원|충북|충남|전북|전남|경북|경남|제주|세종|전국",
                  message = "지역이 유효하지 않습니다.")
         String region
 ) {

--- a/src/main/java/com/server/youthtalktalk/domain/member/dto/SignUpRequestDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/member/dto/SignUpRequestDto.java
@@ -27,7 +27,8 @@ public class SignUpRequestDto {
     private String nickname;
 
     @NotBlank(message = "지역은 필수값입니다.")
-    @Pattern(regexp = "서울|부산|대구|인천|광주|대전|울산|경기|강원|충북|충남|전북|전남|경북|경남|제주|세종", message = "지역이 유효하지 않습니다.")
+    @Pattern(regexp = "서울|부산|대구|인천|광주|대전|울산|경기|강원|충북|충남|전북|전남|경북|경남|제주|세종|전국",
+             message = "지역이 유효하지 않습니다.")
     private String region;
 
     private String idToken;

--- a/src/main/java/com/server/youthtalktalk/domain/policy/controller/PolicyController.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/controller/PolicyController.java
@@ -34,10 +34,9 @@ public class PolicyController {
      * 홈 화면 정책 조회 (우리 지역 인기 정책 + 따끈따끈 새로운 정책)
      */
     @GetMapping("/policies")
-    public BaseResponse<Map<String, List<PolicyListResponseDto>>> getHomePolicies(@RequestParam(required = false) List<Region> regions,
-                                                                                             @RequestParam(required = false) List<Category> categories) {
-        List<PolicyListResponseDto> top20Policies = policyService.getTop20Policies(regions);
-        List<PolicyListResponseDto> newPolicies = policyService.getNewPoliciesByCategories(regions, categories);
+    public BaseResponse<Map<String, List<PolicyListResponseDto>>> getHomePolicies(@RequestParam(required = false) List<Category> categories) {
+        List<PolicyListResponseDto> top20Policies = policyService.getTop20Policies();
+        List<PolicyListResponseDto> newPolicies = policyService.getNewPoliciesByCategories(categories);
 
         Map<String, List<PolicyListResponseDto>> responseMap = new LinkedHashMap<>();
         responseMap.put("top20Policies", top20Policies);

--- a/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/dto/data/PolicyData.java
@@ -164,7 +164,7 @@ public record PolicyData(
                     .orElse(null);
         }
         else{
-            return Region.ALL; // 이외는 중앙부처 처리
+            return Region.CENTER; // 이외는 중앙부처 처리
         }
     }
 

--- a/src/main/java/com/server/youthtalktalk/domain/policy/entity/region/Region.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/entity/region/Region.java
@@ -23,7 +23,8 @@ public enum Region {
     GYEONGNAM("6480000","경남", 48),
     JEJU("6500000","제주", 50),
     SEJONG("5690000","세종", 36),
-    ALL("중앙부처","전국", -1);
+    NATIONWIDE("전국", "전국", -1),
+    CENTER("중앙부처","중앙부처", -1);
 
     private final String key;
     private final String name;

--- a/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyRepository.java
@@ -4,6 +4,7 @@ import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.policy.entity.Category;
 import com.server.youthtalktalk.domain.policy.entity.Policy;
 import com.server.youthtalktalk.domain.policy.entity.region.Region;
+import lombok.NonNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -20,52 +21,42 @@ import java.util.Optional;
 public interface PolicyRepository extends JpaRepository<Policy,String>, PolicyQueryRepository {
 
     /**
-     * top20 정책 조회 (조회수순)
-     * 특정 지역 선택
+     * 전체 지역의 top20 정책 조회
      */
-    @Query("SELECT p FROM Policy p WHERE p.region = :region OR p.region = 'CENTER' ORDER BY p.view DESC")
-    Page<Policy> findTop20ByRegionOrderByViewsDesc(@Param("region") Region region, Pageable pageable);
+    @NonNull
+    Page<Policy> findAll(@NonNull Pageable pageable);
 
     /**
-     * top20 정책 조회 (조회수순)
-     * 모든 지역 선택
+     * 특정 지역의 top20 정책 조회
      */
-    @Query("SELECT p FROM Policy p ORDER BY p.view DESC")
-    Page<Policy> findTop20OrderByViewsDesc(Pageable pageable);
+    @Query("SELECT p FROM Policy p WHERE p.region = :region OR p.region = 'CENTER'")
+    Page<Policy> findTop20ByRegion(@Param("region") Region region, Pageable pageable);
+
+    /**
+     * 오늘 포함 지난 7일의 정책 조회 (카테고리 필터링 X)
+     */
+    @Query("SELECT p FROM Policy p " +
+            "WHERE p.createdAt BETWEEN :from AND :to ")
+    Page<Policy> findRecentPolicies(@Param("from") LocalDateTime from,
+                                    @Param("to") LocalDateTime to,
+                                    Pageable pageable);
+
+    /**
+     * 오늘 포함 지난 7일의 정책 조회 (카테고리 필터링 O)
+     */
+    @Query("SELECT p FROM Policy p " +
+            "WHERE p.category IN :categories " +
+            "AND p.createdAt BETWEEN :from AND :to")
+    Page<Policy> findRecentPoliciesByCategory(@Param("categories") List<Category> categories,
+                                              @Param("from") LocalDateTime from,
+                                              @Param("to") LocalDateTime to,
+                                              Pageable pageable);
 
     /**
      * 카테고리별 정책 조회 (최신순) - 카테고리 중복 선택 가능
      */
     @Query("SELECT p FROM Policy p WHERE (p.region = :region OR p.region = 'CENTER') AND (p.category IN :categories) ORDER BY p.policyNum DESC")
     Page<Policy> findByRegionAndCategory(@Param("region") Region region, @Param("categories") List<Category> categories, Pageable pageable);
-
-
-    /**
-     * 오늘 포함 지난 7일의 정책 조회 (최신순)
-     * 여러 지역 선택 가능
-     */
-    @Query("SELECT p FROM Policy p " +
-            "WHERE (p.region IN :regions OR p.region = 'CENTER') " +
-            "AND p.category IN :categories " +
-            "AND p.createdAt BETWEEN :from AND :to " +
-            "ORDER BY p.createdAt DESC")
-    Page<Policy> findRecentPoliciesByRegionAndCategory(@Param("regions") List<Region> regions,
-                                                       @Param("categories") List<Category> categories,
-                                                       @Param("from") LocalDateTime from,
-                                                       @Param("to") LocalDateTime to,
-                                                       Pageable pageable);
-    /**
-     * 오늘 포함 지난 7일의 정책 조회 (최신순)
-     * 모든 지역 선택
-     */
-    @Query("SELECT p FROM Policy p " +
-            "WHERE p.category IN :categories " +
-            "AND p.createdAt BETWEEN :from AND :to " +
-            "ORDER BY p.createdAt DESC")
-    Page<Policy> findRecentPoliciesByCategory(@Param("categories") List<Category> categories,
-                                              @Param("from") LocalDateTime from,
-                                              @Param("to") LocalDateTime to,
-                                              Pageable pageable);
 
     /**
      * 이름으로 정책 조회 (최신순)

--- a/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/repository/PolicyRepository.java
@@ -21,10 +21,10 @@ public interface PolicyRepository extends JpaRepository<Policy,String>, PolicyQu
 
     /**
      * top20 정책 조회 (조회수순)
-     * 여러 지역 선택 가능
+     * 특정 지역 선택
      */
-    @Query("SELECT p FROM Policy p WHERE p.region IN :regions OR p.region = 'ALL' ORDER BY p.view DESC")
-    Page<Policy> findTop20ByRegionsOrderByViewsDesc(@Param("regions") List<Region> regions, Pageable pageable);
+    @Query("SELECT p FROM Policy p WHERE p.region = :region OR p.region = 'CENTER' ORDER BY p.view DESC")
+    Page<Policy> findTop20ByRegionOrderByViewsDesc(@Param("region") Region region, Pageable pageable);
 
     /**
      * top20 정책 조회 (조회수순)
@@ -36,7 +36,7 @@ public interface PolicyRepository extends JpaRepository<Policy,String>, PolicyQu
     /**
      * 카테고리별 정책 조회 (최신순) - 카테고리 중복 선택 가능
      */
-    @Query("SELECT p FROM Policy p WHERE (p.region = :region OR p.region = 'ALL') AND (p.category IN :categories) ORDER BY p.policyNum DESC")
+    @Query("SELECT p FROM Policy p WHERE (p.region = :region OR p.region = 'CENTER') AND (p.category IN :categories) ORDER BY p.policyNum DESC")
     Page<Policy> findByRegionAndCategory(@Param("region") Region region, @Param("categories") List<Category> categories, Pageable pageable);
 
 
@@ -45,7 +45,7 @@ public interface PolicyRepository extends JpaRepository<Policy,String>, PolicyQu
      * 여러 지역 선택 가능
      */
     @Query("SELECT p FROM Policy p " +
-            "WHERE (p.region IN :regions OR p.region = 'ALL') " +
+            "WHERE (p.region IN :regions OR p.region = 'CENTER') " +
             "AND p.category IN :categories " +
             "AND p.createdAt BETWEEN :from AND :to " +
             "ORDER BY p.createdAt DESC")
@@ -62,15 +62,15 @@ public interface PolicyRepository extends JpaRepository<Policy,String>, PolicyQu
             "WHERE p.category IN :categories " +
             "AND p.createdAt BETWEEN :from AND :to " +
             "ORDER BY p.createdAt DESC")
-    Page<Policy> findRecentPoliciesAndCategory(@Param("categories") List<Category> categories,
-                                                       @Param("from") LocalDateTime from,
-                                                       @Param("to") LocalDateTime to,
-                                                       Pageable pageable);
+    Page<Policy> findRecentPoliciesByCategory(@Param("categories") List<Category> categories,
+                                              @Param("from") LocalDateTime from,
+                                              @Param("to") LocalDateTime to,
+                                              Pageable pageable);
 
     /**
      * 이름으로 정책 조회 (최신순)
      */
-    @Query("SELECT p FROM Policy p WHERE (p.region = :region OR p.region = 'ALL') AND  (REPLACE(p.title, ' ', '') LIKE CONCAT('%', :title, '%')) ORDER BY p.policyNum DESC")
+    @Query("SELECT p FROM Policy p WHERE (p.region = :region OR p.region = 'CENTER') AND  (REPLACE(p.title, ' ', '') LIKE CONCAT('%', :title, '%')) ORDER BY p.policyNum DESC")
     Page<Policy> findByRegionAndTitle(@Param("region") Region region, @Param("title") String title, Pageable pageable);
 
     /**

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyService.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyService.java
@@ -11,9 +11,9 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface PolicyService {
-    List<PolicyListResponseDto> getTop20Policies(List<Region> regions);
+    List<PolicyListResponseDto> getTop20Policies();
     List<PolicyListResponseDto> getPoliciesByCategories(List<Category> categories, Pageable pageable);
-    List<PolicyListResponseDto> getNewPoliciesByCategories(List<Region> regions, List<Category> categories);
+    List<PolicyListResponseDto> getNewPoliciesByCategories(List<Category> categories);
     SearchConditionResponseDto getPoliciesByCondition(SearchConditionRequestDto condition, Pageable pageable, SortOption sortOption);
     List<SearchNameResponseDto> getPoliciesByName(String title, Pageable pageable);
     PolicyDetailResponseDto getPolicyDetail(Long policyId);

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
@@ -146,7 +146,7 @@ public class PolicyServiceImpl implements PolicyService {
         LocalDateTime toDateTime = today.plusDays(1).atStartOfDay(); // 오늘 24시
 
         PageRequest pageRequest = PageRequest.of(0, 20, Sort.by(
-                Sort.Order.desc("policyNum")     // 2순위 - 조회수 같으면 최신순
+                Sort.Order.desc("policyNum")     // 1순위 - 최신순
         ));
 
         List<Policy> policies;

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
@@ -380,7 +380,7 @@ public class PolicyServiceImpl implements PolicyService {
     }
 
     private void resolveToSubRegionId(Set<Long> subRegionIds, String name) {
-        Region region = Region.fromName(name); // 지역 입력값이 상위 지역 이름과 매핑 시도
+        Region region = Region.fromName(name); // 지역 입력값으로 상위 지역 찾기
 
         // 상위 지역과 매핑 성공 시, 상위 지역이 갖고 있는 모든 하위 지역 저장
         if (region != null) {

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/data/PolicyDataServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/data/PolicyDataServiceImpl.java
@@ -66,7 +66,7 @@ public class PolicyDataServiceImpl implements PolicyDataService {
         // 하위 지역 코드 매핑
         List<PolicySubRegion> policySubRegionList = new ArrayList<>();
         savedPolicyList.stream()
-                .filter(policy -> !policy.getRegion().equals(Region.ALL))
+                .filter(policy -> !policy.getRegion().equals(Region.CENTER))
                 .forEach(policy -> policySubRegionList.addAll(setPolicySubRegions(policy)));
         policySubRegionRepository.saveAll(policySubRegionList);
     }
@@ -276,11 +276,11 @@ public class PolicyDataServiceImpl implements PolicyDataService {
         if(!regionCodes[0].isBlank()){
             Region region = Region.fromNum(Integer.valueOf(regionCodes[0].substring(0,2)));
             if(region == null){
-                return Region.ALL;
+                return Region.CENTER;
             }
             return region;
         }
-        return Region.ALL;
+        return Region.CENTER;
     }
 
     private Policy setRegionForPolicy(Policy policy) {

--- a/src/test/java/com/server/youthtalktalk/repository/policy/PolicyQueryRepositoryTest.java
+++ b/src/test/java/com/server/youthtalktalk/repository/policy/PolicyQueryRepositoryTest.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
@@ -395,7 +394,7 @@ public class PolicyQueryRepositoryTest {
                 .earn(ANNUL_INCOME)
                 .marriage(Marriage.UNRESTRICTED)
                 .category(JOB)
-                .region(Region.ALL)
+                .region(Region.CENTER)
                 .build();
         return policyRepository.save(policy);
     }

--- a/src/test/java/com/server/youthtalktalk/repository/post/PostRepositoryCustomTest.java
+++ b/src/test/java/com/server/youthtalktalk/repository/post/PostRepositoryCustomTest.java
@@ -82,7 +82,7 @@ public class PostRepositoryCustomTest {
                 .repeatCode(RepeatCode.PERIOD)
                 .earn(Earn.UNRESTRICTED)
                 .institutionType(InstitutionType.CENTER)
-                .region(Region.ALL)
+                .region(Region.CENTER)
                 .marriage(Marriage.UNRESTRICTED)
                 .build());
 

--- a/src/test/java/com/server/youthtalktalk/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/comment/CommentServiceTest.java
@@ -451,7 +451,7 @@ class CommentServiceTest {
                 .earn(Earn.UNRESTRICTED)
                 .marriage(Marriage.UNRESTRICTED)
                 .institutionType(InstitutionType.CENTER)
-                .region(Region.ALL)
+                .region(Region.CENTER)
                 .build();
     }
 

--- a/src/test/java/com/server/youthtalktalk/service/post/PostServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/post/PostServiceTest.java
@@ -80,7 +80,7 @@ class PostServiceTest {
                         .category(Category.JOB)
                         .repeatCode(RepeatCode.PERIOD)
                         .earn(Earn.UNRESTRICTED)
-                        .region(Region.ALL)
+                        .region(Region.CENTER)
                         .institutionType(InstitutionType.CENTER)
                         .marriage(Marriage.UNRESTRICTED)
                         .build());


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #43  

### ⛳ 작업 분류
- [x] `Region.NATIONWIDE` (전국) 추가
- [x] 회원가입 및 회원정보 수정 API의 요청 DTO에서 region 필드에 `전국` 허용
- [x] 홈화면 정책 조회 API에서 우리지역 인기 정책 조회 시, 회원이 선택한 관심지역의 인기 정책을 반환하도록 수정
- [x] 홈화면 정책 조회 API에서 새로 나온 정책 조회 시, 카테고리로만 필터링 하도록 지역 필터링 제거
- [x] API 명세서 업데이트

### 🔨 작업 상세 내용
1. `Region.NATIONWIDE` (전국) 추가
회원의 관심지역이 "전체 지역"일 경우를 위해 Region Enum에 전국을 추가했습니다. null을 할당하는 방식도 고려했지만, null은 의미가 불분명하고 코드 해석에 혼란을 줄 수 있어 사용하지 않았습니다. 추가로, 기존의 `Region.ALL`을 `Region.CENTER`로 이름을 바꾸고 관련 코드들(PolicyRepository의 쿼리 등)도 이에 맞춰 수정했습니다.

2. 회원가입 및 회원정보 수정 API 수정
해당 API의 요청 DTO에서 region 필드에 `Region.NATIONWIDE`(전국)이 허용되도록 수정했습니다. 

3. 홈화면 정책 조회 API 수정
- 우리지역 인기 정책은 회원의 관심지역 내에서 조회수가 높은 20개의 정책을 반환하도록 지역 필터링 로직을 수정했습니다. 관심지역을 기반으로 자동으로 필터링이 적용되기 때문에 요청에서 별도의 지역 옵션은 받지 않습니다. 
- 새로 나온 정책은 관심지역 기반으로 지역 필터링을 적용하지 않는 섹션이기 때문에 카테고리로만 필터링하도록 수정했습니다.
- 정렬 기준을 레포지토리가 아닌 서비스 계층에서 결정하도록 수정했습니다.

### 📍 참고 사항
기획 측 확인 내용을 바탕으로 홈화면 정책 조회 API를 수정했습니다.
- 홈화면에서 선택하는 지역(관심지역)은 다중선택이 불가능하고 한 가지만 선택 가능
- 관심지역 기반 자동 필터링은 ‘우리지역 인기 정책’ 섹션에만 적용