### PR TITLE
[FIX] 댓글 조회 API 응답 수정

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/controller/CommentController.java
@@ -51,20 +51,34 @@ public class CommentController {
      * 정책 댓글 조회 api
      */
     @GetMapping("/policies/{policyId}/comments")
-    public BaseResponse<List<CommentDto>> getPolicyComments(@PathVariable Long policyId) {
-        List<PolicyComment> policyComments = commentService.getPolicyComments(policyId);
-        List<CommentDto> commentDtoList = commentService.toCommentDtoList(policyComments, memberService.getCurrentMember());
-        return new BaseResponse<>(commentDtoList, SUCCESS);
+    public BaseResponse<CommentListResponseDto> getPolicyComments(@PathVariable Long policyId) {
+        Member member = memberService.getCurrentMember();
+        List<PolicyComment> policyComments = commentService.getPolicyComments(policyId, member);
+
+        if (policyComments.isEmpty()) {
+            return new BaseResponse<>(SUCCESS_COMMENT_EMPTY);
+        }
+
+        List<CommentDto> commentDtoList = commentService.toCommentDtoList(policyComments, member);
+        CommentListResponseDto response = new CommentListResponseDto(commentDtoList.size(), commentDtoList);
+        return new BaseResponse<>(response, SUCCESS);
     }
 
     /**
      * 게시글 댓글 조회 api
      */
     @GetMapping("/posts/{postId}/comments")
-    public BaseResponse<List<CommentDto>> getPostComments(@PathVariable Long postId) {
-        List<PostComment> postComments = commentService.getPostComments(postId);
-        List<CommentDto> commentDtoList = commentService.toCommentDtoList(postComments, memberService.getCurrentMember());
-        return new BaseResponse<>(commentDtoList, SUCCESS);
+    public BaseResponse<CommentListResponseDto> getPostComments(@PathVariable Long postId) {
+        Member member = memberService.getCurrentMember();
+        List<PostComment> postComments = commentService.getPostComments(postId, member);
+
+        if (postComments.isEmpty()) {
+            return new BaseResponse<>(SUCCESS_COMMENT_EMPTY);
+        }
+
+        List<CommentDto> commentDtoList = commentService.toCommentDtoList(postComments, member);
+        CommentListResponseDto response = new CommentListResponseDto(commentDtoList.size(), commentDtoList);
+        return new BaseResponse<>(response, SUCCESS);
     }
 
     /**

--- a/src/main/java/com/server/youthtalktalk/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/controller/CommentController.java
@@ -51,7 +51,7 @@ public class CommentController {
      * 정책 댓글 조회 api
      */
     @GetMapping("/policies/{policyId}/comments")
-    public BaseResponse<CommentListResponseDto> getPolicyComments(@PathVariable Long policyId) {
+    public BaseResponse<CommentListDto> getPolicyComments(@PathVariable Long policyId) {
         Member member = memberService.getCurrentMember();
         List<PolicyComment> policyComments = commentService.getPolicyComments(policyId, member);
 
@@ -60,7 +60,7 @@ public class CommentController {
         }
 
         List<CommentDto> commentDtoList = commentService.toCommentDtoList(policyComments, member);
-        CommentListResponseDto response = new CommentListResponseDto(commentDtoList.size(), commentDtoList);
+        CommentListDto response = new CommentListDto(policyComments.size(), commentDtoList);
         return new BaseResponse<>(response, SUCCESS);
     }
 
@@ -68,7 +68,7 @@ public class CommentController {
      * 게시글 댓글 조회 api
      */
     @GetMapping("/posts/{postId}/comments")
-    public BaseResponse<CommentListResponseDto> getPostComments(@PathVariable Long postId) {
+    public BaseResponse<CommentListDto> getPostComments(@PathVariable Long postId) {
         Member member = memberService.getCurrentMember();
         List<PostComment> postComments = commentService.getPostComments(postId, member);
 
@@ -77,37 +77,40 @@ public class CommentController {
         }
 
         List<CommentDto> commentDtoList = commentService.toCommentDtoList(postComments, member);
-        CommentListResponseDto response = new CommentListResponseDto(commentDtoList.size(), commentDtoList);
+        CommentListDto response = new CommentListDto(postComments.size(), commentDtoList);
         return new BaseResponse<>(response, SUCCESS);
     }
 
     /**
-     * 회원이 작성한 댓글 조회 api
+     * 내 댓글 조회 api
      */
     @GetMapping("/members/me/comments")
-    public BaseResponse<List<MyCommentDto>> getMemberComments() {
+    public BaseResponse<MyCommentListDto> getMemberComments() {
         Member member = memberService.getCurrentMember();
         List<Comment> comments = commentService.getMyComments(member);
 
-        if (comments.isEmpty()) // 회원이 작성한 댓글이 없는 경우
+        if (comments.isEmpty())
             return new BaseResponse<>(SUCCESS_COMMENT_EMPTY);
 
-        List<MyCommentDto> myCommentDtoList = commentService.toMyCommentDtoList(comments, member.getNickname());
-        return new BaseResponse<>(myCommentDtoList, SUCCESS);
+        List<MyCommentDto> myCommentDtoList = commentService.toMyCommentDtoList(comments, member);
+        MyCommentListDto response = new MyCommentListDto(comments.size(), myCommentDtoList);
+        return new BaseResponse<>(response, SUCCESS);
     }
 
     /**
      * 회원이 좋아요한 댓글 조회 api
      */
     @GetMapping("/members/me/comments/likes")
-    public BaseResponse<List<MyCommentDto>> getLikedComments() {
-        List<Comment> likedComments = commentService.getLikedComments(memberService.getCurrentMember());
+    public BaseResponse<LikeCommentListDto> getLikedComments() {
+        Member member = memberService.getCurrentMember();
+        List<Comment> likeComments = commentService.getLikedComments(member);
 
-        if(likedComments.isEmpty()) // 회원이 좋아요한 댓글이 없는 경우
+        if(likeComments.isEmpty())
             return new BaseResponse<>(SUCCESS_COMMENT_EMPTY);
 
-        List<MyCommentDto> likedCommentDtoList = commentService.toMyCommentDtoList(likedComments, null);
-        return new BaseResponse<>(likedCommentDtoList, SUCCESS);
+        List<LikeCommentDto> likeCommentDtoList = commentService.toLikeCommentDtoList(likeComments, member);
+        LikeCommentListDto response = new LikeCommentListDto(likeComments.size(), likeCommentDtoList);
+        return new BaseResponse<>(response, SUCCESS);
     }
 
     /**

--- a/src/main/java/com/server/youthtalktalk/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/dto/CommentDto.java
@@ -1,8 +1,12 @@
 package com.server.youthtalktalk.domain.comment.dto;
 
-public record CommentDto (
+public record CommentDto(
         Long commentId,
+        Long writerId,
         String nickname,
+        String profileImg,
         String content,
-        Boolean isLikedByMember) {
+        Boolean isLikedByMember,
+        String createdAt
+) {
 }

--- a/src/main/java/com/server/youthtalktalk/domain/comment/dto/CommentListDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/dto/CommentListDto.java
@@ -2,8 +2,8 @@ package com.server.youthtalktalk.domain.comment.dto;
 
 import java.util.List;
 
-public record CommentListResponseDto(
-        long commentCount,
+public record CommentListDto(
+        int commentCount,
         List<CommentDto> comments
 ) {
 }

--- a/src/main/java/com/server/youthtalktalk/domain/comment/dto/CommentListResponseDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/dto/CommentListResponseDto.java
@@ -1,0 +1,9 @@
+package com.server.youthtalktalk.domain.comment.dto;
+
+import java.util.List;
+
+public record CommentListResponseDto(
+        long commentCount,
+        List<CommentDto> comments
+) {
+}

--- a/src/main/java/com/server/youthtalktalk/domain/comment/dto/LikeCommentDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/dto/LikeCommentDto.java
@@ -1,7 +1,9 @@
 package com.server.youthtalktalk.domain.comment.dto;
 
-public record MyCommentDto(
+public record LikeCommentDto(
         Long commentId,
+        Long writerId,
+        String nickname,
         String content,
         Long articleId,
         String articleType,

--- a/src/main/java/com/server/youthtalktalk/domain/comment/dto/LikeCommentListDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/dto/LikeCommentListDto.java
@@ -1,0 +1,9 @@
+package com.server.youthtalktalk.domain.comment.dto;
+
+import java.util.List;
+
+public record LikeCommentListDto(
+        int commentCount,
+        List<LikeCommentDto> comments
+) {
+}

--- a/src/main/java/com/server/youthtalktalk/domain/comment/dto/MyCommentListDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/dto/MyCommentListDto.java
@@ -1,0 +1,9 @@
+package com.server.youthtalktalk.domain.comment.dto;
+
+import java.util.List;
+
+public record MyCommentListDto(
+        int commentCount,
+        List<MyCommentDto> comments
+) {
+}

--- a/src/main/java/com/server/youthtalktalk/domain/comment/dto/PolicyCommentDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/dto/PolicyCommentDto.java
@@ -1,4 +1,0 @@
-package com.server.youthtalktalk.domain.comment.dto;
-
-public record PolicyCommentDto(Long commentId, String nickname, String content, Long policyId) implements MyCommentDto{
-}

--- a/src/main/java/com/server/youthtalktalk/domain/comment/dto/PostCommentDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/dto/PostCommentDto.java
@@ -1,4 +1,0 @@
-package com.server.youthtalktalk.domain.comment.dto;
-
-public record PostCommentDto(Long commentId, String nickname, String content, Long postId) implements MyCommentDto {
-}

--- a/src/main/java/com/server/youthtalktalk/domain/comment/entity/Comment.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/entity/Comment.java
@@ -6,6 +6,7 @@ import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.report.entity.CommentReport;
 import com.server.youthtalktalk.domain.report.entity.PostReport;
 import jakarta.persistence.*;
+import java.util.Objects;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
@@ -59,4 +60,18 @@ public abstract class Comment extends BaseTimeEntity {
 
     // 연관엔티티(post/policy) id 조회
     public abstract Long getRelatedEntityId();
+
+    @Override
+    public boolean equals(Object object) {
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        Comment comment = (Comment) object;
+        return Objects.equals(id, comment.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/comment/entity/Comment.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/entity/Comment.java
@@ -4,7 +4,6 @@ import com.server.youthtalktalk.domain.BaseTimeEntity;
 import com.server.youthtalktalk.domain.likes.entity.Likes;
 import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.report.entity.CommentReport;
-import com.server.youthtalktalk.domain.report.entity.PostReport;
 import jakarta.persistence.*;
 import java.util.Objects;
 import lombok.*;
@@ -53,13 +52,15 @@ public abstract class Comment extends BaseTimeEntity {
         like.setComment(null);
     }
 
-    // content 업데이트
     public void updateContent(String content) {
         this.content = content;
     }
 
-    // 연관엔티티(post/policy) id 조회
-    public abstract Long getRelatedEntityId();
+    public abstract Long getArticleId();
+
+    public abstract String getArticleType();
+
+    public abstract String getArticleTitle();
 
     @Override
     public boolean equals(Object object) {

--- a/src/main/java/com/server/youthtalktalk/domain/comment/entity/PolicyComment.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/entity/PolicyComment.java
@@ -25,7 +25,17 @@ public class PolicyComment extends Comment{
     }
 
     @Override
-    public Long getRelatedEntityId() {
+    public Long getArticleId() {
         return policy.getPolicyId();
+    }
+
+    @Override
+    public String getArticleType() {
+        return "policy";
+    }
+
+    @Override
+    public String getArticleTitle() {
+        return policy.getTitle();
     }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/comment/entity/PostComment.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/entity/PostComment.java
@@ -1,12 +1,14 @@
 package com.server.youthtalktalk.domain.comment.entity;
 
 import com.server.youthtalktalk.domain.post.entity.Post;
+import com.server.youthtalktalk.domain.post.entity.Review;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.Hibernate;
 
 @Entity
 @Getter
@@ -33,7 +35,7 @@ public class PostComment extends Comment{
 
     @Override
     public String getArticleType() {
-        return "post";
+        return ((Hibernate.getClass(post).equals(Review.class))) ? "review" : "post";
     }
 
     @Override

--- a/src/main/java/com/server/youthtalktalk/domain/comment/entity/PostComment.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/entity/PostComment.java
@@ -27,7 +27,17 @@ public class PostComment extends Comment{
     }
 
     @Override
-    public Long getRelatedEntityId() {
+    public Long getArticleId() {
         return post.getId();
+    }
+
+    @Override
+    public String getArticleType() {
+        return "post";
+    }
+
+    @Override
+    public String getArticleTitle() {
+        return post.getTitle();
     }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/repository/CommentRepository.java
@@ -14,13 +14,13 @@ import java.util.List;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    // 게시글 댓글 조회 + 오래된 순 정렬
-    @Query("SELECT pc FROM PostComment pc WHERE pc.post.id = :postId ORDER BY pc.createdAt ASC")
-    List<PostComment> findPostCommentsByPostIdOrderByCreatedAtAsc(@Param("postId") Long postId);
+    // 특정 게시글의 전체 댓글 조회
+    @Query("SELECT pc FROM PostComment pc WHERE pc.post.id = :postId ")
+    List<PostComment> findPostCommentsByPostId(@Param("postId") Long postId);
 
-    // 정책 댓글 조회 + 오래된 순 정렬
-    @Query("SELECT pc FROM PolicyComment pc WHERE pc.policy.policyId = :policyId ORDER BY pc.createdAt ASC")
-    List<PolicyComment> findPolicyCommentsByPolicyIdOrderByCreatedAtAsc(@Param("policyId") Long policyId);
+    // 특정 정책의 전체 댓글 조회
+    @Query("SELECT pc FROM PolicyComment pc WHERE pc.policy.policyId = :policyId")
+    List<PolicyComment> findPolicyCommentsByPolicyId(@Param("policyId") Long policyId);
 
     // 회원이 작성한 댓글 조회 + 최신 순 정렬
     List<Comment> findCommentsByWriterOrderByCreatedAtDesc(Member writer);

--- a/src/main/java/com/server/youthtalktalk/domain/comment/service/CommentService.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/service/CommentService.java
@@ -1,10 +1,10 @@
 package com.server.youthtalktalk.domain.comment.service;
 
+import com.server.youthtalktalk.domain.comment.dto.CommentDto;
 import com.server.youthtalktalk.domain.comment.entity.Comment;
 import com.server.youthtalktalk.domain.comment.entity.PolicyComment;
 import com.server.youthtalktalk.domain.comment.entity.PostComment;
 import com.server.youthtalktalk.domain.member.entity.Member;
-import com.server.youthtalktalk.domain.comment.dto.CommentDto;
 import com.server.youthtalktalk.domain.comment.dto.MyCommentDto;
 
 import java.util.List;
@@ -12,8 +12,8 @@ import java.util.List;
 public interface CommentService {
     PolicyComment createPolicyComment(Long policyId, String content, Member member);
     PostComment createPostComment(Long postId, String content, Member member);
-    List<PolicyComment> getPolicyComments(Long policyId);
-    List<PostComment> getPostComments(Long postId);
+    List<PolicyComment> getPolicyComments(Long policyId, Member member);
+    List<PostComment> getPostComments(Long postId, Member member);
     List<Comment> getMyComments(Member member);
     List<Comment> getLikedComments(Member member);
     List<CommentDto> toCommentDtoList(List<? extends Comment> comments, Member member);

--- a/src/main/java/com/server/youthtalktalk/domain/comment/service/CommentService.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/service/CommentService.java
@@ -1,11 +1,12 @@
 package com.server.youthtalktalk.domain.comment.service;
 
 import com.server.youthtalktalk.domain.comment.dto.CommentDto;
+import com.server.youthtalktalk.domain.comment.dto.LikeCommentDto;
+import com.server.youthtalktalk.domain.comment.dto.MyCommentDto;
 import com.server.youthtalktalk.domain.comment.entity.Comment;
 import com.server.youthtalktalk.domain.comment.entity.PolicyComment;
 import com.server.youthtalktalk.domain.comment.entity.PostComment;
 import com.server.youthtalktalk.domain.member.entity.Member;
-import com.server.youthtalktalk.domain.comment.dto.MyCommentDto;
 
 import java.util.List;
 
@@ -17,7 +18,8 @@ public interface CommentService {
     List<Comment> getMyComments(Member member);
     List<Comment> getLikedComments(Member member);
     List<CommentDto> toCommentDtoList(List<? extends Comment> comments, Member member);
-    List<MyCommentDto> toMyCommentDtoList(List<Comment> comments, String nickname);
+    List<MyCommentDto> toMyCommentDtoList(List<Comment> comments, Member member);
+    List<LikeCommentDto> toLikeCommentDtoList(List<Comment> comments, Member member);
     void updateComment(Long commentId, String content);
     void deleteComment(Long commentId);
     boolean isLikedByMember(Comment comment, Member member);

--- a/src/main/java/com/server/youthtalktalk/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/service/CommentServiceImpl.java
@@ -1,26 +1,24 @@
 package com.server.youthtalktalk.domain.comment.service;
 
 import com.server.youthtalktalk.domain.comment.dto.CommentDto;
+import com.server.youthtalktalk.domain.comment.dto.LikeCommentDto;
 import com.server.youthtalktalk.domain.comment.dto.MyCommentDto;
-import com.server.youthtalktalk.domain.comment.dto.PolicyCommentDto;
-import com.server.youthtalktalk.domain.comment.dto.PostCommentDto;
 import com.server.youthtalktalk.domain.comment.entity.Comment;
 import com.server.youthtalktalk.domain.comment.entity.PolicyComment;
 import com.server.youthtalktalk.domain.comment.entity.PostComment;
 import com.server.youthtalktalk.domain.comment.repository.CommentRepository;
 import com.server.youthtalktalk.domain.likes.entity.Likes;
 import com.server.youthtalktalk.domain.likes.repository.LikeRepository;
-import com.server.youthtalktalk.domain.member.entity.Block;
 import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.member.repository.BlockRepository;
 import com.server.youthtalktalk.domain.member.repository.MemberRepository;
 import com.server.youthtalktalk.domain.policy.entity.Policy;
 import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
 import com.server.youthtalktalk.domain.post.entity.Post;
+import com.server.youthtalktalk.domain.post.entity.Review;
 import com.server.youthtalktalk.domain.post.repostiory.PostRepository;
 import com.server.youthtalktalk.domain.report.entity.CommentReport;
 import com.server.youthtalktalk.domain.report.repository.ReportRepository;
-import com.server.youthtalktalk.global.response.BaseResponseCode;
 import com.server.youthtalktalk.global.response.exception.BusinessException;
 import com.server.youthtalktalk.global.response.exception.InvalidValueException;
 import com.server.youthtalktalk.global.response.exception.comment.AlreadyLikedException;
@@ -40,6 +38,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.server.youthtalktalk.global.response.BaseResponseCode.*;
 import static com.server.youthtalktalk.global.response.BaseResponseCode.INVALID_INPUT_VALUE;
 
 @Slf4j
@@ -48,7 +47,7 @@ import static com.server.youthtalktalk.global.response.BaseResponseCode.INVALID_
 @RequiredArgsConstructor
 public class CommentServiceImpl implements CommentService {
 
-    public static final String DELETED_WRITER = "탈퇴한 회원";
+    public static final String DELETED_WRITER = "알 수 없음";
     public static final String DEFAULT_PROFILE = "기본 이미지";
     public static final String COMMENT_TIME_FORMAT = "yyyy-MM-dd HH:mm";
 
@@ -87,7 +86,7 @@ public class CommentServiceImpl implements CommentService {
     }
 
     /**
-     * 정책 댓글 조회
+     * 정책 댓글 조회 (오래된 순)
      */
     @Override
     public List<PolicyComment> getPolicyComments(Long policyId, Member member) {
@@ -104,7 +103,7 @@ public class CommentServiceImpl implements CommentService {
     }
 
     /**
-     * 게시글 댓글 조회
+     * 게시글 댓글 조회 (오래된 순)
      */
     @Override
     public List<PostComment> getPostComments(Long postId, Member member) {
@@ -135,7 +134,7 @@ public class CommentServiceImpl implements CommentService {
     }
 
     /**
-     * 회원이 작성한 댓글 조회
+     * 회원이 작성한 댓글 조회 (최신순)
      */
     @Override
     public List<Comment> getMyComments(Member member) {
@@ -143,16 +142,16 @@ public class CommentServiceImpl implements CommentService {
     }
 
     /**
-     * 회원이 좋아요한 댓글 조회
+     * 회원이 좋아요한 댓글 조회 (최신순)
      */
     @Override
     public List<Comment> getLikedComments(Member member) {
         return likeRepository.findAllByMemberOrderByCreatedAtDesc(member)
-                .stream().map(Likes::getComment).collect(Collectors.toList());
+                .stream().map(Likes::getComment).toList();
     }
 
     /**
-     * CommentDto로 변환
+     * 게시글/정책 댓글 조회용 DTO 리스트로 변환
      */
     @Override
     public List<CommentDto> toCommentDtoList(List<? extends Comment> comments, Member member) {
@@ -160,37 +159,59 @@ public class CommentServiceImpl implements CommentService {
                 .map(comment -> {
                     Member writer = comment.getWriter();
                     Long writerId = (writer == null) ? -1L : writer.getId();
-                    String writerNickname = (writer == null) ? DELETED_WRITER : writer.getNickname();
-                    String writerProfileImg = (writer == null || writer.getProfileImage() == null)
+                    String nickname = (writer == null) ? DELETED_WRITER : writer.getNickname();
+                    String profileImg = (writer == null || writer.getProfileImage() == null)
                             ? DEFAULT_PROFILE : writer.getProfileImage().getImgUrl();
                     String content = comment.getContent();
                     String createdAt = comment.getCreatedAt()
                             .format(DateTimeFormatter.ofPattern(COMMENT_TIME_FORMAT));
                     Boolean isLikedByMember = isLikedByMember(comment, member);
-                    return new CommentDto(comment.getId(), writerId, writerNickname, writerProfileImg, content, isLikedByMember, createdAt);
+                    return new CommentDto(comment.getId(), writerId, nickname, profileImg, content, isLikedByMember, createdAt);
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**
-     * 연관엔티티 id 있는 CommentDto로 변환 (마이페이지 용)
+     * 내가 작성한 댓글 조회용 DTO 리스트로 변환
      */
     @Override
-    public List<MyCommentDto> toMyCommentDtoList(List<Comment> comments, String nickname) {
+    public List<MyCommentDto> toMyCommentDtoList(List<Comment> comments, Member member) {
         return comments.stream()
                 .map(comment -> {
-                    String writerNickname = (nickname != null) ? nickname : comment.getWriter().getNickname();
-                    Long relatedEntityId = comment.getRelatedEntityId();
-
-                    if (comment instanceof PolicyComment) {
-                        return new PolicyCommentDto(comment.getId(), writerNickname, comment.getContent(), relatedEntityId);
-                    } else if (comment instanceof PostComment) {
-                        return new PostCommentDto(comment.getId(), writerNickname, comment.getContent(), relatedEntityId);
-                    } else {
-                        throw new BusinessException(BaseResponseCode.COMMENT_TYPE_UNKNOWN);
-                    }
+                    Long commentId = comment.getId();
+                    String content = comment.getContent();
+                    Long articleId = comment.getArticleId();
+                    String articleType = comment.getArticleType();
+                    String articleTitle = comment.getArticleTitle();
+                    Boolean isLikedByMember = isLikedByMember(comment, member);
+                    int likeCount = comment.getCommentLikes().size();
+                    return new MyCommentDto(commentId, content, articleId,
+                            articleType, articleTitle, isLikedByMember, likeCount);
                 })
-                .collect(Collectors.toList());
+                .toList();
+    }
+
+    /**
+     * 좋아요한 댓글 조회용 DTO 리스트로 변환
+     */
+    @Override
+    public List<LikeCommentDto> toLikeCommentDtoList(List<Comment> comments, Member member) {
+        return comments.stream()
+                .map(comment -> {
+                    Long commentId = comment.getId();
+                    Member writer = comment.getWriter();
+                    Long writerId = (writer == null) ? -1L : writer.getId();
+                    String nickname = (writer == null) ? DELETED_WRITER : writer.getNickname();
+                    String content = comment.getContent();
+                    Long articleId = comment.getArticleId();
+                    String articleType = comment.getArticleType();
+                    String articleTitle = comment.getArticleTitle();
+                    Boolean isLikedByMember = isLikedByMember(comment, member);
+                    int likeCount = comment.getCommentLikes().size();
+                    return new LikeCommentDto(commentId, writerId, nickname, content, articleId,
+                            articleType, articleTitle, isLikedByMember, likeCount);
+                })
+                .toList();
     }
 
     /**

--- a/src/main/java/com/server/youthtalktalk/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/comment/service/CommentServiceImpl.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -58,6 +59,7 @@ public class CommentServiceImpl implements CommentService {
     private final MemberRepository memberRepository;
     private final ReportRepository reportRepository;
     private final BlockRepository blockRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 정책 댓글 생성

--- a/src/main/java/com/server/youthtalktalk/domain/member/repository/BlockRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/member/repository/BlockRepository.java
@@ -2,13 +2,23 @@ package com.server.youthtalktalk.domain.member.repository;
 
 import com.server.youthtalktalk.domain.member.entity.Block;
 import com.server.youthtalktalk.domain.member.entity.Member;
+import java.util.List;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
 public interface BlockRepository extends JpaRepository<Block, Long> {
+
     Optional<Block> findByMemberAndBlockedMember(Member member, Member blockedMember);
+
     boolean existsByMemberAndBlockedMember(Member member, Member blockedMember);
+
+    @Query("SELECT b.blockedMember FROM Block b WHERE b.member = :member")
+    List<Member> findBlockedMembersByBlocker(@Param("member") Member member);
+
 }

--- a/src/main/java/com/server/youthtalktalk/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/report/repository/ReportRepository.java
@@ -2,9 +2,12 @@ package com.server.youthtalktalk.domain.report.repository;
 
 import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.post.entity.Post;
+import com.server.youthtalktalk.domain.report.entity.CommentReport;
 import com.server.youthtalktalk.domain.report.entity.Report;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -15,4 +18,7 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
 
     @Query("SELECT COUNT(cr) > 0 FROM CommentReport cr WHERE cr.comment.id = :commentId AND cr.reporter.id = :reporterId")
     boolean existsByComment_IdAndReporter_Id(Long commentId, Long reporterId);
+
+    @Query("SELECT cr FROM CommentReport cr WHERE cr.reporter = :reporter")
+    List<CommentReport> findCommentReportsByReporter(@Param("reporter") Member reporter);
 }

--- a/src/test/java/com/server/youthtalktalk/repository/comment/CommentRepositoryTest.java
+++ b/src/test/java/com/server/youthtalktalk/repository/comment/CommentRepositoryTest.java
@@ -1,0 +1,81 @@
+package com.server.youthtalktalk.repository.comment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.server.youthtalktalk.domain.comment.entity.PolicyComment;
+import com.server.youthtalktalk.domain.comment.entity.PostComment;
+import com.server.youthtalktalk.domain.comment.repository.CommentRepository;
+import com.server.youthtalktalk.domain.policy.entity.InstitutionType;
+import com.server.youthtalktalk.domain.policy.entity.Policy;
+import com.server.youthtalktalk.domain.policy.entity.RepeatCode;
+import com.server.youthtalktalk.domain.policy.entity.condition.Marriage;
+import com.server.youthtalktalk.domain.policy.entity.region.Region;
+import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
+import com.server.youthtalktalk.domain.post.entity.Post;
+import com.server.youthtalktalk.domain.post.repostiory.PostRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+public class CommentRepositoryTest {
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private PolicyRepository policyRepository;
+
+    @Test
+    @DisplayName("postId로 특정 게시글의 전체 댓글 조회")
+    void testFindPostCommentsByPostId() {
+        // given
+        Post post = postRepository.save(Post.builder().title("post1").build());
+        PostComment comment1 = commentRepository.save(PostComment.builder().post(post).content("post comment1").build());
+        PostComment comment2 = commentRepository.save(PostComment.builder().post(post).content("post comment2").build());
+
+        // when
+        List<PostComment> postComments = commentRepository.findPostCommentsByPostId(post.getId());
+
+        // then
+        assertThat(postComments.size()).isEqualTo(2);
+        assertThat(postComments).extracting("content").containsExactly("post comment1", "post comment2");
+    }
+
+    @Test
+    @DisplayName("policyId로 특정 정책의 전체 댓글 조회")
+    void testGetPolicyComments() {
+        // given
+        Policy policy = createPolicy();
+        policyRepository.save(policy);
+        PolicyComment comment1 = commentRepository.save(PolicyComment.builder().policy(policy).content("policy comment1").build());
+        PolicyComment comment2 = commentRepository.save(PolicyComment.builder().policy(policy).content("policy comment2").build());
+
+        // when
+        List<PolicyComment> policyComments = commentRepository.findPolicyCommentsByPolicyId(policy.getPolicyId());
+
+        // then
+        assertThat(policyComments.size()).isEqualTo(2);
+        assertThat(policyComments).extracting("content").containsExactly("policy comment1", "policy comment2");
+    }
+
+    private static Policy createPolicy() {
+        return Policy.builder()
+                .policyNum("policyNum1")
+                .region(Region.SEOUL)
+                .title("policy1")
+                .institutionType(InstitutionType.CENTER)
+                .repeatCode(RepeatCode.PERIOD)
+                .marriage(Marriage.SINGLE)
+                .build();
+    }
+}

--- a/src/test/java/com/server/youthtalktalk/service/comment/CommentReadServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/comment/CommentReadServiceTest.java
@@ -1,19 +1,27 @@
 package com.server.youthtalktalk.service.comment;
 
+import static com.server.youthtalktalk.domain.comment.service.CommentServiceImpl.*;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.server.youthtalktalk.domain.comment.dto.LikeCommentDto;
+import com.server.youthtalktalk.domain.comment.dto.MyCommentDto;
 import com.server.youthtalktalk.domain.comment.entity.Comment;
 import com.server.youthtalktalk.domain.comment.entity.PolicyComment;
 import com.server.youthtalktalk.domain.comment.entity.PostComment;
 import com.server.youthtalktalk.domain.comment.repository.CommentRepository;
 import com.server.youthtalktalk.domain.comment.service.CommentServiceImpl;
+import com.server.youthtalktalk.domain.likes.entity.Likes;
+import com.server.youthtalktalk.domain.likes.repository.LikeRepository;
 import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.member.repository.BlockRepository;
+import com.server.youthtalktalk.domain.policy.entity.Policy;
+import com.server.youthtalktalk.domain.policy.entity.region.Region;
 import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
+import com.server.youthtalktalk.domain.post.entity.Post;
 import com.server.youthtalktalk.domain.post.repostiory.PostRepository;
 import com.server.youthtalktalk.domain.report.entity.CommentReport;
 import com.server.youthtalktalk.domain.report.repository.ReportRepository;
@@ -23,6 +31,7 @@ import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,6 +57,9 @@ public class CommentReadServiceTest {
 
     @Mock
     private PolicyRepository policyRepository;
+
+    @Mock
+    private LikeRepository likeRepository;
 
     @Mock
     private CommentRepository commentRepository;
@@ -190,6 +202,136 @@ public class CommentReadServiceTest {
 
         // when & then
         assertThrows(PolicyNotFoundException.class, () -> commentService.getPolicyComments(policyId, member));
+    }
+
+    @Test
+    @DisplayName("내 댓글 조회 시, 회원이 작성한 모든 댓글을 최신순으로 정렬하여 반환한다.")
+    void testGetMyComments() {
+        // given
+        Member member = Member.builder().id(1L).username("member1").build();
+        Comment comment1 = PostComment.builder().id(1L).content("content1").build();
+        Comment comment2 = PostComment.builder().id(2L).content("content2").build();
+
+        comment1.setWriter(member);
+        comment2.setWriter(member);
+
+        // 최신순 정렬로 가정 (comment2가 더 나중에 작성됨)
+        List<Comment> mockComments = List.of(comment2, comment1);
+        Mockito.when(commentRepository.findCommentsByWriterOrderByCreatedAtDesc(member)).thenReturn(mockComments);
+
+        // when
+        List<Comment> comments = commentService.getMyComments(member);
+
+        // then
+        Assertions.assertThat(comments.size()).isEqualTo(2);
+        Assertions.assertThat(comments).containsExactly(comment2, comment1); // 최신순 검증
+    }
+
+    @Test
+    @DisplayName("toMyCommentDtoList - PostComment인 경우 변환 성공")
+    void toMyCommentDtoList_PostComment() {
+        // given
+        Member member = Member.builder().id(1L).username("member1").build();
+        Post post = Post.builder().id(10L).title("게시글 제목").build();
+        PostComment comment = PostComment.builder().id(100L).content("댓글 내용").build();
+        comment.setWriter(member);
+        comment.setPost(post);
+
+        List<Comment> comments = List.of(comment);
+
+        // when
+        List<MyCommentDto> result = commentService.toMyCommentDtoList(comments, member);
+
+        // then
+        assertThat(result).hasSize(1);
+        MyCommentDto dto = result.get(0);
+        assertThat(dto.commentId()).isEqualTo(comment.getId());
+        assertThat(dto.content()).isEqualTo(comment.getContent());
+        assertThat(dto.articleId()).isEqualTo(post.getId());
+        assertThat(dto.articleType()).isEqualTo("post");
+        assertThat(dto.articleTitle()).isEqualTo(post.getTitle());
+        assertThat(dto.isLikedByMember()).isFalse();
+        assertThat(dto.likeCount()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("toMyCommentDtoList - PolicyComment인 경우 변환 성공")
+    void toMyCommentDtoList_PolicyComment() {
+        // given
+        Member member = Member.builder().id(1L).username("member1").build();
+        Policy policy = Policy.builder().policyId(1L).build();
+        PolicyComment comment = PolicyComment.builder().id(100L).content("댓글 내용").build();
+        comment.setWriter(member);
+        comment.setPolicy(policy);
+
+        List<Comment> comments = List.of(comment);
+
+        // when
+        List<MyCommentDto> result = commentService.toMyCommentDtoList(comments, member);
+
+        // then
+        assertThat(result).hasSize(1);
+        MyCommentDto dto = result.get(0);
+        assertThat(dto.commentId()).isEqualTo(comment.getId());
+        assertThat(dto.content()).isEqualTo(comment.getContent());
+        assertThat(dto.articleId()).isEqualTo(policy.getPolicyId());
+        assertThat(dto.articleType()).isEqualTo("policy");
+        assertThat(dto.articleTitle()).isEqualTo(policy.getTitle());
+        assertThat(dto.isLikedByMember()).isFalse();
+        assertThat(dto.likeCount()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("좋아요한 댓글 조회 시, 회원이 좋아요한 댓글을 최신순으로 반환한다.")
+    void testGetLikedComments() {
+        // given
+        Member member = Member.builder().id(1L).username("member1").build();
+        Comment comment1 = PostComment.builder().id(1L).content("content1").build();
+        Comment comment2 = PostComment.builder().id(2L).content("content1").build();
+
+        Likes like1 = Likes.builder().comment(comment1).build();
+        Likes like2 = Likes.builder().comment(comment2).build();
+
+        like1.setMember(member);
+        like1.setComment(comment1);
+        like2.setMember(member);
+        like2.setComment(comment2);
+
+        // 최신순 정렬로 가정 (comment2가 더 나중에 좋아요됨)
+        List<Likes> likesList = List.of(like2, like1);
+        Mockito.when(likeRepository.findAllByMemberOrderByCreatedAtDesc(member)).thenReturn(likesList);
+
+        // when
+        List<Comment> likedComments = commentService.getLikedComments(member);
+
+        // then
+        Assertions.assertThat(likedComments).hasSize(2);
+        Assertions.assertThat(likedComments).containsExactly(comment2, comment1); // 최신순 검증
+    }
+
+    @Test
+    @DisplayName("탈퇴한 사용자의 댓글도 LikeCommentDto로 변환된다")
+    void toLikeCommentDtoList_writerIsNull() {
+        // given
+        Post post = Post.builder().id(1L).title("게시글1").build();
+        PostComment comment = PostComment.builder().id(1L).content("내용").build();
+        comment.setPost(post);
+        comment.setWriter(null);
+
+        List<Comment> comments = List.of(comment);
+        Member member = Member.builder().id(2L).build();
+
+        // when
+        List<LikeCommentDto> result = commentService.toLikeCommentDtoList(comments, member);
+
+        // then
+        assertThat(result).hasSize(1);
+        LikeCommentDto dto = result.get(0);
+
+        assertThat(dto.writerId()).isEqualTo(-1L);
+        assertThat(dto.nickname()).isEqualTo(DELETED_WRITER);
+        assertThat(dto.commentId()).isEqualTo(comment.getId());
+        assertThat(dto.content()).isEqualTo(comment.getContent());
     }
 
 }

--- a/src/test/java/com/server/youthtalktalk/service/comment/CommentReadServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/comment/CommentReadServiceTest.java
@@ -1,0 +1,195 @@
+package com.server.youthtalktalk.service.comment;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.server.youthtalktalk.domain.comment.entity.Comment;
+import com.server.youthtalktalk.domain.comment.entity.PolicyComment;
+import com.server.youthtalktalk.domain.comment.entity.PostComment;
+import com.server.youthtalktalk.domain.comment.repository.CommentRepository;
+import com.server.youthtalktalk.domain.comment.service.CommentServiceImpl;
+import com.server.youthtalktalk.domain.member.entity.Member;
+import com.server.youthtalktalk.domain.member.repository.BlockRepository;
+import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
+import com.server.youthtalktalk.domain.post.repostiory.PostRepository;
+import com.server.youthtalktalk.domain.report.entity.CommentReport;
+import com.server.youthtalktalk.domain.report.repository.ReportRepository;
+import com.server.youthtalktalk.global.response.exception.policy.PolicyNotFoundException;
+import com.server.youthtalktalk.global.response.exception.post.PostNotFoundException;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class CommentReadServiceTest {
+
+    @Mock
+    private BlockRepository blockRepository;
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private PolicyRepository policyRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @InjectMocks
+    private CommentServiceImpl commentService;
+
+    @Test
+    @DisplayName("제외 댓글 조회 시, 사용자가 차단한 유저의 댓글과 신고한 댓글을 반환한다.")
+    void testGetExcludedComments() {
+        // given
+        Member member = mock(Member.class);
+        Member blockedUser = mock(Member.class);
+        CommentReport report = mock(CommentReport.class);
+        Comment blockedComment = mock(Comment.class);
+        Comment reportedComment = mock(Comment.class);
+
+        when(blockRepository.findBlockedMembersByBlocker(member)).thenReturn(List.of(blockedUser));
+        when(blockedUser.getComments()).thenReturn(List.of(blockedComment));
+        when(reportRepository.findCommentReportsByReporter(member)).thenReturn(List.of(report));
+        when(report.getComment()).thenReturn(reportedComment);
+
+        // when
+        Set<Comment> excludedComments = commentService.getExcludedComments(member);
+
+        // then
+        assertThat(excludedComments).containsExactlyInAnyOrder(blockedComment, reportedComment);
+    }
+
+    @Test
+    @DisplayName("제외 댓글 조회 시, 차단한 댓글과 신고한 댓글이 동일하면 중복은 제거한다.")
+    void testGetExcludedCommentsDuplication() {
+        // given
+        Member member = mock(Member.class);
+        Member blockedUser = mock(Member.class);
+        CommentReport report = mock(CommentReport.class);
+        Comment duplicateComment = mock(Comment.class); // 차단한 유저의 댓글이면서 신고한 댓글인 경우
+
+        when(blockRepository.findBlockedMembersByBlocker(member)).thenReturn(List.of(blockedUser));
+        when(blockedUser.getComments()).thenReturn(List.of(duplicateComment));
+        when(reportRepository.findCommentReportsByReporter(member)).thenReturn(List.of(report));
+        when(report.getComment()).thenReturn(duplicateComment);
+
+        // when
+        Set<Comment> excludedComments = commentService.getExcludedComments(member);
+
+        // then
+        assertThat(excludedComments).hasSize(1); // 중복 제거되어 하나만 있음
+    }
+
+    @Test
+    @DisplayName("게시글 댓글 조회 시, 차단/신고 댓글은 제외하고 작성일 오름차순으로 반환한다.")
+    void testGetPostCommentsFilteredAndSorted() {
+        // given
+        Long postId = 1L;
+        Member member = mock(Member.class);
+
+        PostComment pc1 = mock(PostComment.class);
+        PostComment pc2 = mock(PostComment.class);
+        PostComment pc3 = mock(PostComment.class);
+
+        when(pc1.getCreatedAt()).thenReturn(LocalDateTime.of(2024, 1, 1, 0, 0));
+        when(pc2.getCreatedAt()).thenReturn(LocalDateTime.of(2024, 1, 3, 0, 0));
+        when(pc3.getCreatedAt()).thenReturn(LocalDateTime.of(2024, 1, 2, 0, 0));
+
+        List<PostComment> allComments = List.of(pc1, pc2, pc3);
+        Set<Comment> excludedComments = Set.of(pc2);  // 차단/신고된 댓글은 제외됨
+
+        when(postRepository.existsById(postId)).thenReturn(true);
+        when(commentRepository.findPostCommentsByPostId(postId)).thenReturn(allComments);
+
+        // 제외 댓글은 spy로 반환
+        CommentServiceImpl commentServiceSpy = Mockito.spy(commentService);
+        doReturn(excludedComments).when(commentServiceSpy).getExcludedComments(member);
+
+        // when
+        List<PostComment> result = commentServiceSpy.getPostComments(postId, member);
+
+        // then
+        assertThat(result).containsExactly(pc1, pc3);  // pc2는 제외되어야 함
+        assertThat(result).isSortedAccordingTo(Comparator.comparing(PostComment::getCreatedAt));  // 오래된 순 정렬
+    }
+
+    @Test
+    @DisplayName("게시글 댓글 조회 시, 존재하지 않는 게시글이면 예외를 발생시킨다.")
+    void testGetPostCommentsWhenPostNotFound() {
+        // given
+        Long postId = 1L;
+        Member member = mock(Member.class);
+
+        // 게시글이 존재하지 않는 경우
+        when(postRepository.existsById(postId)).thenReturn(false);
+
+        // when & then
+        assertThrows(PostNotFoundException.class, () -> commentService.getPostComments(postId, member));
+    }
+
+    @Test
+    @DisplayName("정책 댓글 조회 시, 차단/신고 댓글은 제외하고 작성일 오름차순으로 반환한다.")
+    void testGetPolicyCommentsFilteredAndSorted() {
+        // given
+        Long policyId = 1L;
+        Member member = mock(Member.class);
+
+        PolicyComment pc1 = mock(PolicyComment.class);
+        PolicyComment pc2 = mock(PolicyComment.class);
+        PolicyComment pc3 = mock(PolicyComment.class);
+
+        when(pc1.getCreatedAt()).thenReturn(LocalDateTime.of(2024, 1, 1, 0, 0));
+        when(pc2.getCreatedAt()).thenReturn(LocalDateTime.of(2024, 1, 3, 0, 0));
+        when(pc3.getCreatedAt()).thenReturn(LocalDateTime.of(2024, 1, 2, 0, 0));
+
+        List<PolicyComment> allComments = List.of(pc1, pc2, pc3);
+        Set<Comment> excludedComments = Set.of(pc2);  // 차단/신고된 댓글은 제외됨
+
+        when(policyRepository.existsByPolicyId(policyId)).thenReturn(true);
+        when(commentRepository.findPolicyCommentsByPolicyId(policyId)).thenReturn(allComments);
+
+        // 제외 댓글은 spy로 반환
+        CommentServiceImpl commentServiceSpy = Mockito.spy(commentService);
+        doReturn(excludedComments).when(commentServiceSpy).getExcludedComments(member);
+
+        // when
+        List<PolicyComment> result = commentServiceSpy.getPolicyComments(policyId, member);
+
+        // then
+        assertThat(result).containsExactly(pc1, pc3);  // pc2는 제외되어야 함
+        assertThat(result).isSortedAccordingTo(Comparator.comparing(PolicyComment::getCreatedAt));  // 오래된 순 정렬
+    }
+
+    @Test
+    @DisplayName("정책 댓글 조회 시, 존재하지 않는 정책이면 예외를 발생시킨다.")
+    void testGetPolicyCommentsWhenPolicyNotFound() {
+        // given
+        Long policyId = 1L;
+        Member member = mock(Member.class);
+
+        // 정책이 존재하지 않는 경우
+        when(policyRepository.existsByPolicyId(policyId)).thenReturn(false);
+
+        // when & then
+        assertThrows(PolicyNotFoundException.class, () -> commentService.getPolicyComments(policyId, member));
+    }
+
+}

--- a/src/test/java/com/server/youthtalktalk/service/comment/CommentReadServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/comment/CommentReadServiceTest.java
@@ -22,6 +22,7 @@ import com.server.youthtalktalk.domain.policy.entity.Policy;
 import com.server.youthtalktalk.domain.policy.entity.region.Region;
 import com.server.youthtalktalk.domain.policy.repository.PolicyRepository;
 import com.server.youthtalktalk.domain.post.entity.Post;
+import com.server.youthtalktalk.domain.post.entity.Review;
 import com.server.youthtalktalk.domain.post.repostiory.PostRepository;
 import com.server.youthtalktalk.domain.report.entity.CommentReport;
 import com.server.youthtalktalk.domain.report.repository.ReportRepository;
@@ -232,10 +233,10 @@ public class CommentReadServiceTest {
     void toMyCommentDtoList_PostComment() {
         // given
         Member member = Member.builder().id(1L).username("member1").build();
-        Post post = Post.builder().id(10L).title("게시글 제목").build();
+        Review review = Review.builder().id(10L).title("리뷰 제목").build();
         PostComment comment = PostComment.builder().id(100L).content("댓글 내용").build();
         comment.setWriter(member);
-        comment.setPost(post);
+        comment.setPost(review);
 
         List<Comment> comments = List.of(comment);
 
@@ -247,9 +248,9 @@ public class CommentReadServiceTest {
         MyCommentDto dto = result.get(0);
         assertThat(dto.commentId()).isEqualTo(comment.getId());
         assertThat(dto.content()).isEqualTo(comment.getContent());
-        assertThat(dto.articleId()).isEqualTo(post.getId());
-        assertThat(dto.articleType()).isEqualTo("post");
-        assertThat(dto.articleTitle()).isEqualTo(post.getTitle());
+        assertThat(dto.articleId()).isEqualTo(review.getId());
+        assertThat(dto.articleType()).isEqualTo("review");
+        assertThat(dto.articleTitle()).isEqualTo(review.getTitle());
         assertThat(dto.isLikedByMember()).isFalse();
         assertThat(dto.likeCount()).isEqualTo(0);
     }

--- a/src/test/java/com/server/youthtalktalk/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/comment/CommentServiceTest.java
@@ -1,6 +1,5 @@
 package com.server.youthtalktalk.service.comment;
 
-import com.server.youthtalktalk.domain.comment.dto.CommentDto;
 import com.server.youthtalktalk.domain.likes.entity.Likes;
 import com.server.youthtalktalk.domain.comment.service.CommentService;
 import com.server.youthtalktalk.domain.comment.entity.Comment;
@@ -11,7 +10,6 @@ import com.server.youthtalktalk.domain.likes.repository.LikeRepository;
 import com.server.youthtalktalk.domain.member.entity.Member;
 import com.server.youthtalktalk.domain.member.repository.MemberRepository;
 import com.server.youthtalktalk.domain.member.entity.Role;
-import com.server.youthtalktalk.domain.member.service.MemberService;
 import com.server.youthtalktalk.domain.policy.entity.InstitutionType;
 import com.server.youthtalktalk.domain.policy.entity.Policy;
 import com.server.youthtalktalk.domain.policy.entity.RepeatCode;
@@ -24,7 +22,6 @@ import com.server.youthtalktalk.domain.post.repostiory.PostRepository;
 import com.server.youthtalktalk.global.response.exception.policy.PolicyNotFoundException;
 import com.server.youthtalktalk.global.response.exception.post.PostNotFoundException;
 import jakarta.persistence.EntityManager;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -60,10 +57,11 @@ class CommentServiceTest {
     CommentService commentService;
 
     @Autowired
-    MemberService memberService;
-
-    @Autowired
     EntityManager em;
+
+    /**
+     * TODO 조회 관련 테스트 코드는 CommentReadServiceTest로 옮겨야 함
+     */
 
     @Test
     void 정책_댓글_생성_성공() {
@@ -142,116 +140,6 @@ class CommentServiceTest {
         assertThrows(PostNotFoundException.class,
                 () -> commentService.createPostComment(1000L, "content", member));
     }
-
-    @Test
-    @DisplayName("policyId로 특정 정책의 모든 댓글 조회_성공")
-    void testGetPolicyComments() {
-        // given
-        Member member = Member.builder().username("member1").nickname("member1").region(Region.SEOUL).role(Role.USER).build();
-        memberRepository.save(member);
-
-        Policy policy = createPolicy("policyNum");
-        policyRepository.save(policy);
-
-        PolicyComment policyComment1 = PolicyComment.builder().policy(policy).content("content1").writer(member).build();
-        commentRepository.save(policyComment1);
-        PolicyComment policyComment3 = PolicyComment.builder().policy(policy).content("content3").writer(member).build();
-        commentRepository.save(policyComment3);
-        PolicyComment policyComment2 = PolicyComment.builder().policy(policy).content("content2").writer(member).build();
-        commentRepository.save(policyComment2);
-
-        // when
-        List<PolicyComment> policyComments = commentService.getPolicyComments(policy.getPolicyId());
-
-        // then
-        assertThat(policyComments.size()).isEqualTo(3);
-        assertThat(policyComments.get(0).getId()).isEqualTo(policyComment1.getId());
-        assertThat(policyComments.get(1).getId()).isEqualTo(policyComment3.getId());
-        assertThat(policyComments.get(2).getId()).isEqualTo(policyComment2.getId());
-    }
-
-    @Test
-    @DisplayName("postId로 특정 게시글의 모든 댓글 조회_성공")
-    void testGetPostComments() {
-        // given
-        Member member = Member.builder().username("member1").nickname("member1").region(Region.SEOUL).role(Role.USER).build();
-        memberRepository.save(member);
-
-        Post post = Post.builder().build();
-        postRepository.save(post);
-
-        PostComment postComment1 = PostComment.builder().post(post).writer(member).content("content1").build();
-        commentRepository.save(postComment1);
-        PostComment postComment3 = PostComment.builder().post(post).writer(member).content("content1").build();
-        commentRepository.save(postComment3);
-        PostComment postComment2 = PostComment.builder().post(post).writer(member).content("content1").build();
-        commentRepository.save(postComment2);
-
-        // when
-        List<PostComment> postComments = commentService.getPostComments(post.getId());
-
-        // then
-        assertThat(postComments.size()).isEqualTo(3);
-        assertThat(postComments.get(0).getId()).isEqualTo(postComment1.getId());
-        assertThat(postComments.get(1).getId()).isEqualTo(postComment3.getId());
-        assertThat(postComments.get(2).getId()).isEqualTo(postComment2.getId());
-    }
-
-
-    @Test
-    @DisplayName("정책 댓글 조회 시, 차단한 유저가 작성한 댓글 제외_성공")
-    void testToCommentDtoList1() {
-        // given
-        Member member = Member.builder().username("member1").nickname("member1").region(Region.SEOUL).role(Role.USER).build();
-        Member blocked = Member.builder().username("member2").nickname("member2").region(Region.SEOUL).role(Role.USER).build();
-        memberRepository.save(member);
-        memberRepository.save(blocked);
-        memberService.blockMember(member, blocked.getId());
-
-        Post post = Post.builder().build();
-        postRepository.save(post);
-
-        PostComment postComment1 = PostComment.builder().post(post).writer(blocked).content("content1").build();
-        PostComment postComment2 = PostComment.builder().post(post).writer(blocked).content("content2").build();
-        commentRepository.save(postComment1);
-        commentRepository.save(postComment2);
-
-        List<PostComment> postComments = commentService.getPostComments(post.getId());
-
-        // when
-        List<CommentDto> filteredComments = commentService.toCommentDtoList(postComments, member);
-
-        // then
-        assertThat(filteredComments.size()).isEqualTo(0);
-    }
-
-    @Test
-    @DisplayName("게시글 댓글 조회 시, 차단한 유저가 작성한 댓글 제외_성공")
-    void testToCommentDtoList2() {
-        // given
-        Member member = Member.builder().username("member1").nickname("member1").region(Region.SEOUL).role(Role.USER).build();
-        Member blocked = Member.builder().username("member2").nickname("member2").region(Region.SEOUL).role(Role.USER).build();
-        memberRepository.save(member);
-        memberRepository.save(blocked);
-        memberService.blockMember(member, blocked.getId());
-
-        Policy policy = createPolicy("policyNum");
-        policyRepository.save(policy);
-
-        PolicyComment policyComment1 = PolicyComment.builder().policy(policy).content("content1").writer(blocked).build();
-        PolicyComment policyComment2 = PolicyComment.builder().policy(policy).content("content2").writer(blocked).build();
-        commentRepository.save(policyComment1);
-        commentRepository.save(policyComment2);
-
-        List<PolicyComment> policyComments = commentService.getPolicyComments(policy.getPolicyId());
-
-        // when
-        List<CommentDto> filteredComments = commentService.toCommentDtoList(policyComments, member);
-
-        // then
-        assertThat(filteredComments.size()).isEqualTo(0);
-    }
-
 
     @Test
     void 정책_댓글_수정_성공() {

--- a/src/test/java/com/server/youthtalktalk/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/comment/CommentServiceTest.java
@@ -160,7 +160,7 @@ class CommentServiceTest {
         // then
         Comment savedComment = commentRepository.findById(comment.getId()).orElseThrow();
         assertThat(savedComment.getWriter()).isEqualTo(member);
-        assertThat(savedComment.getRelatedEntityId()).isEqualTo(policy.getPolicyId());
+        assertThat(savedComment.getArticleId()).isEqualTo(policy.getPolicyId());
         assertThat(savedComment.getContent().equals("new_content")).isTrue();
 
         assertThat(member.getComments().size()).isEqualTo(1);
@@ -191,7 +191,7 @@ class CommentServiceTest {
         // then
         Comment savedComment = commentRepository.findById(comment.getId()).orElseThrow();
         assertThat(savedComment.getWriter()).isEqualTo(member);
-        assertThat(savedComment.getRelatedEntityId()).isEqualTo(post.getId());
+        assertThat(savedComment.getArticleId()).isEqualTo(post.getId());
         assertThat(savedComment.getContent().equals("new_content")).isTrue();
 
         assertThat(member.getComments().size()).isEqualTo(1);
@@ -220,43 +220,6 @@ class CommentServiceTest {
         // then
         assertThat(commentRepository.findById(comment.getId())).isEmpty();
         assertThat(member.getComments().contains(comment)).isFalse();
-
-    }
-
-    @Test
-    void 회원이_작성한_댓글_조회_성공() {
-        // given
-        Member member = Member.builder().username("member1").nickname("member1").region(Region.SEOUL).build();
-        memberRepository.save(member);
-
-        Comment comment1 = PostComment.builder().content("content1").build();
-        Comment comment2 = PostComment.builder().content("content2").build();
-        comment1.setWriter(member);
-        comment2.setWriter(member);
-        commentRepository.save(comment1);
-        commentRepository.save(comment2);
-
-        // when
-        List<Comment> comments = commentService.getMyComments(member);
-
-        // then
-        assertThat(comments.size()).isEqualTo(2);
-        assertThat(comments.contains(comment1)).isTrue();
-        assertThat(comments.contains(comment2)).isTrue();
-        assertThat(comments.get(0).getId()).isEqualTo(comment2.getId()); // 최신순 정렬 검증
-    }
-
-    @Test
-    void 회원이_작성한_댓글_조회_성공_작성한_댓글이_없음() {
-        // given
-        Member member = Member.builder().username("member1").nickname("member1").region(Region.SEOUL).build();
-        memberRepository.save(member);
-
-        // when
-        List<Comment> comments = commentService.getMyComments(member);
-
-        // then
-        assertThat(comments.isEmpty()).isTrue();
 
     }
 
@@ -301,34 +264,6 @@ class CommentServiceTest {
         assertThat(likeRepository.findById(like.getId())).isNotPresent();
         assertThat(!member.getLikes().contains(like)).isTrue();
         assertThat(!comment.getCommentLikes().contains(like)).isTrue();
-    }
-
-    @Test
-    void 회원이_좋아요한_모든_댓글_조회_성공() {
-        // given
-        Member member = Member.builder().username("member1").nickname("member1").region(Region.SEOUL).build();
-        Comment comment1 = PostComment.builder().content("content1").build();
-        Comment comment2 = PostComment.builder().content("content2").build();
-        Likes like1 = Likes.builder().build();
-        Likes like2 = Likes.builder().build();
-        like1.setMember(member);
-        like2.setMember(member);
-        like1.setComment(comment1);
-        like2.setComment(comment2);
-
-        memberRepository.save(member);
-        commentRepository.save(comment1);
-        commentRepository.save(comment2);
-        likeRepository.save(like1);
-        likeRepository.save(like2);
-
-        // when
-        List<Comment> likedComments = commentService.getLikedComments(member);
-
-        // then
-        assertThat(likedComments.size()).isEqualTo(2);
-        assertThat(likedComments.contains(comment1)).isTrue();
-        assertThat(likedComments.contains(comment2)).isTrue();
     }
 
     private static Policy createPolicy(String policyNum) {


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #45 

### ⛳ 작업 분류
- [x] 게시글/정책 댓글 조회용 DTO 생성
- [x] 내 댓글 조회용 DTO, 좋아요한 댓글 조회용 DTO 생성
- [x] 게시글/정책 댓글 조회 API 코드 수정 및 테스트
- [x] 내 댓글 조회 API 코드 수정 및 테스트
- [x] 좋아요한 댓글 조회 API 코드 수정 및 테스트
- [x] API 명세서 업데이트

### 🔨 작업 상세 내용
1. 댓글 조회는 섹션별로 응답 데이터가 조금씩 달라야해서 디자인에 맞춰서 응답 DTO를 추가했습니다.
2. 댓글 조회와 관련된 모든 API들을 수정하고 테스트 코드를 보완했습니다.

### 📍 참고 사항
- 정렬 기준, 작성일시 형식 등 프론트분들과 논의할 부분들이 있습니다. 제가 임의로 설정했는데, 다음 개발팀 회의 때 말씀드릴 예정입니다.