### PR TITLE
[FIX] PostRepDto 수정

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/post/dto/PostRepDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/dto/PostRepDto.java
@@ -18,7 +18,6 @@ public class PostRepDto {
     private Long writerId;
     private String nickname;
     private Long view;
-    private List<String> images;
     private String category;
     private boolean isScrap;
 }

--- a/src/main/java/com/server/youthtalktalk/domain/post/dto/PostUpdateReqDto.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/dto/PostUpdateReqDto.java
@@ -6,21 +6,22 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
-@Getter
-@Builder
-public class PostUpdateReqDto {
-    @NotBlank(message = "게시글 제목은 필수값입니다.")
-    @Size(max = 50,message = "게시글 제목은 최대 50자입니다.")
-    private String title;
+public record PostUpdateReqDto(
+        @NotBlank(message = "게시글 제목은 필수값입니다.")
+        @Size(max = 50, message = "게시글 제목은 최대 50자입니다.")
+        String title,
 
-    @NotNull(message = "게시글 본문은 필수값입니다.")
-    @Size(min = 1, message = "게시글 본문은 필수값입니다.")
-    private List<Content> contentList;
+        String postType,
 
-    private Long policyId; // 정책을 변경했을 때만
-    private List<String> addImgUrlList;
-    private List<String> deletedImgUrlList;
-}
+        @NotNull(message = "게시글 본문은 필수값입니다.")
+        @Size(min = 1, message = "게시글 본문은 필수값입니다.")
+        List<Content> contentList,
+
+        Long policyId,                  // 정책을 변경했을 때만
+        List<String> addImgUrlList,
+        List<String> deletedImgUrlList
+) {}

--- a/src/main/java/com/server/youthtalktalk/domain/post/entity/Post.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/entity/Post.java
@@ -74,8 +74,7 @@ public class Post extends BaseTimeEntity {
                 .writerId(this.getWriter() == null ? null : this.getWriter().getId())
                 .nickname(this.getWriter() == null ? "null" : this.getWriter().getNickname())
                 .view(this.getView())
-                .images(this.getImages().stream().map(PostImage::getImgUrl).toList())
-                .category(this instanceof Review ? ((Review)this).getPolicy().getCategory().getKey() : null)
+                .category(this instanceof Review ? ((Review)this).getPolicy().getCategory().name() : null)
                 .isScrap(isScrap)
                 .build();
     }

--- a/src/main/java/com/server/youthtalktalk/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/service/PostServiceImpl.java
@@ -81,22 +81,22 @@ public class PostServiceImpl implements PostService{
         }
 
         Post updatedPost = post.toBuilder()
-                .title(postUpdateReqDto.getTitle())
-                .contents(postUpdateReqDto.getContentList())
+                .title(postUpdateReqDto.title())
+                .contents(postUpdateReqDto.contentList())
                 .build();
         if(post instanceof Review){ // 리뷰이면
-            if(postUpdateReqDto.getPolicyId() != null){
-                Policy policy = policyRepository.findByPolicyId(postUpdateReqDto.getPolicyId()).orElseThrow(PolicyNotFoundException::new);
+            if(postUpdateReqDto.policyId() != null){
+                Policy policy = policyRepository.findByPolicyId(postUpdateReqDto.policyId()).orElseThrow(PolicyNotFoundException::new);
                 ((Review)updatedPost).setPolicy(policy);
             }
         }
         Post savedPost = postRepository.save(updatedPost);
         // 추가된 이미지 매핑
-        if(postUpdateReqDto.getAddImgUrlList()!=null&&!postUpdateReqDto.getAddImgUrlList().isEmpty()){
-            imageService.mappingPostImage(postUpdateReqDto.getAddImgUrlList(),savedPost);
+        if(postUpdateReqDto.addImgUrlList()!=null&&!postUpdateReqDto.addImgUrlList().isEmpty()){
+            imageService.mappingPostImage(postUpdateReqDto.addImgUrlList(),savedPost);
         }
-        if(postUpdateReqDto.getDeletedImgUrlList()!=null&&!postUpdateReqDto.getDeletedImgUrlList().isEmpty()){
-            imageService.deleteMultiFile(postUpdateReqDto.getDeletedImgUrlList());
+        if(postUpdateReqDto.deletedImgUrlList()!=null&&!postUpdateReqDto.deletedImgUrlList().isEmpty()){
+            imageService.deleteMultiFile(postUpdateReqDto.deletedImgUrlList());
         }
         log.info("게시글 수정 성공, postId = {}", savedPost.getId());
         return savedPost.toPostRepDto(scrapRepository.existsByMemberIdAndItemIdAndItemType(writer.getId(),post.getId(),ItemType.POST));

--- a/src/test/java/com/server/youthtalktalk/service/post/PostReadServiceTest.java
+++ b/src/test/java/com/server/youthtalktalk/service/post/PostReadServiceTest.java
@@ -308,7 +308,7 @@ public class PostReadServiceTest {
         PostListResponse result = postReadService.getAllMyPost(pageable, member);
         // Then
         assertThat(result.getPosts()).hasSize(LEN);
-        assertThat(result.getPosts().getFirst().getWriterId()).isEqualTo(member.getId());
+        assertThat(result.getPosts().get(0).getWriterId()).isEqualTo(member.getId());
 
         verify(postRepositoryCustom).findAllPostsByWriter(pageable, member);
     }
@@ -394,7 +394,7 @@ public class PostReadServiceTest {
         // When
         PostListResponse scrapPostList = postReadService.getScrapPostList(pageable, member);
         // Then
-        PostListDto first = scrapPostList.getPosts().getFirst();
+        PostListDto first = scrapPostList.getPosts().get(0);
         assertThat(scrapPostList.getPosts()).hasSize(LEN);
         assertThat(first.getPostId()).isEqualTo(posts.get(0).getId());
         assertThat(first.getTitle()).isEqualTo(posts.get(0).getTitle());
@@ -440,7 +440,7 @@ public class PostReadServiceTest {
         // When
         PostListResponse scrapPostList = postReadService.getScrapPostList(pageable, member);
         // Then
-        PostListDto first = scrapPostList.getPosts().getFirst();
+        PostListDto first = scrapPostList.getPosts().get(0);
         assertThat(scrapPostList.getPosts()).hasSize(1);
         assertThat(first.getScrapCount()).isEqualTo(1);
         assertThat(first.getPolicyTitle()).isEqualTo(policy.getTitle());


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #34 

### ⛳ 작업 분류
- [x] PostRepDto(게시글 생성, 수정, 상세 조회) 시 응답값 수정

### 🔨 작업 상세 내용
1. 카테고리는 번호가 아닌 이름으로 반환(JOB, DWELLING 등)
2. images필드 삭제(contentList 필드와 중복)
3. PostUpdateReqDto record클래스로 변경
4. 관련 테스트 코드 수정

### 📍 참고 사항
- PostServiceTest에서 getFirst() 메서드 사용 시 저는 자바 17로 작업 중이라 인식하지 못하는 에러가 발생했습니다. 해당 메서드는 자바 21부터 사용 가능하다고 하더라구요. 이 부분 우선 get(0)으로 수정했습니다.
