### PR TITLE
[FIX] 게시글 조회 시 수정일이 변경되는 문제 해결

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/BaseTimeEntity.java
+++ b/src/main/java/com/server/youthtalktalk/domain/BaseTimeEntity.java
@@ -27,7 +27,7 @@ public abstract class BaseTimeEntity {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    public void setUpdatedAt(){
+    public void setUpdatedAt() {
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/repository/RecentViewedPolicyRepository.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/repository/RecentViewedPolicyRepository.java
@@ -17,7 +17,5 @@ public interface RecentViewedPolicyRepository extends JpaRepository<RecentViewed
     void deleteAllByMember(Member member);
     Optional<RecentViewedPolicy> findByMemberAndPolicy(Member member, Policy policy);
     int countAllByMember(Member member);
-    Optional<RecentViewedPolicy> findFirstByMemberOrderByCreatedAt(Member member);
-    @Query("update RecentViewedPolicy set updatedAt = :updatedAt where id = :id")
-    void updateRecentViewedPolicyUpdatedAt(Long id, LocalDateTime updatedAt);
+    Optional<RecentViewedPolicy> findFirstByMemberOrderByUpdatedAt(Member member);
 }

--- a/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/policy/service/PolicyServiceImpl.java
@@ -561,7 +561,7 @@ public class PolicyServiceImpl implements PolicyService {
         else{
             recentViewedPolicyRepository.save(RecentViewedPolicy.builder().member(member).policy(policy).build());
             if(recentViewedPolicyRepository.countAllByMember(member) > 20){
-                RecentViewedPolicy firstViewedPolicy = recentViewedPolicyRepository.findFirstByMemberOrderByCreatedAt(member).get();
+                RecentViewedPolicy firstViewedPolicy = recentViewedPolicyRepository.findFirstByMemberOrderByUpdatedAt(member).get();
                 recentViewedPolicyRepository.delete(firstViewedPolicy);
             }
         }

--- a/src/main/java/com/server/youthtalktalk/domain/post/entity/Post.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/entity/Post.java
@@ -10,7 +10,10 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,7 +24,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "post_type")
-public class Post extends BaseTimeEntity {
+public class Post{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,6 +42,12 @@ public class Post extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member writer;
+
+    @Column(updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
 
     @ElementCollection
     @CollectionTable(name = "post_contents", joinColumns = @JoinColumn(name = "post_id"))
@@ -62,6 +71,10 @@ public class Post extends BaseTimeEntity {
         if (member != null) {
             member.getPosts().add(this);
         }
+    }
+
+    public void setUpdatedAt(){
+        this.updatedAt = LocalDateTime.now();
     }
 
     public PostRepDto toPostRepDto(boolean isScrap) {

--- a/src/main/java/com/server/youthtalktalk/domain/post/service/PostReadServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/service/PostReadServiceImpl.java
@@ -64,7 +64,7 @@ public class PostReadServiceImpl implements PostReadService {
             throw new BlockedMemberPostAccessDeniedException();
         }
 
-        postRepository.save(post.toBuilder().view(post.getView()+1).updatedAt(post.getUpdatedAt()).build());
+        postRepository.save(post.toBuilder().view(post.getView()+1).build());
         log.info("게시글 조회 성공, postId = {}", postId);
         return post.toPostRepDto(scrapRepository.existsByMemberIdAndItemIdAndItemType(member.getId(),post.getId(), POST));
     }

--- a/src/main/java/com/server/youthtalktalk/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/service/PostServiceImpl.java
@@ -49,6 +49,7 @@ public class PostServiceImpl implements PostService{
             post = Post.builder()
                     .title(postCreateReqDto.title())
                     .contents(postCreateReqDto.contentList())
+                    .updatedAt(LocalDateTime.now())
                     .view(0L)
                     .build();
         }
@@ -56,6 +57,7 @@ public class PostServiceImpl implements PostService{
             Review review = Review.builder()
                     .title(postCreateReqDto.title())
                     .contents(postCreateReqDto.contentList())
+                    .updatedAt(LocalDateTime.now())
                     .view(0L)
                     .build();
             Policy policy = policyRepository.findByPolicyId(postCreateReqDto.policyId()).orElseThrow(PolicyNotFoundException::new);
@@ -83,6 +85,7 @@ public class PostServiceImpl implements PostService{
         Post updatedPost = post.toBuilder()
                 .title(postUpdateReqDto.title())
                 .contents(postUpdateReqDto.contentList())
+                .updatedAt(LocalDateTime.now())
                 .build();
         if(post instanceof Review){ // 리뷰이면
             if(postUpdateReqDto.policyId() != null){


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #34 

### ⛳ 작업 분류
- [x] 게시글 조회 시 수정일이 변경되는 현상 해결
- [x] 최근 본 정책 조회 시 createdAt이 아닌 updatedAt 순으로 정렬 조회  

### 🔨 작업 상세 내용
1. 게시글 조회 시 조회수를 1씩 증가시키면서 `@LastModifiedDate`로 인해 updatedAt이 같이 변경됐습니다.
2. 게시글은 `@LastModifiedDate` 사용안하고 직접 updatedAt 설정으로 변경했습니다.
3. 최근 본 정책 조회 시 생성일 기준이 아닌 수정일 기준으로 정렬하여, 같은 정책을 여러번 조회 시 순서가 반영되게 했습니다.
