### PR TITLE
[FIX] 게시글 생성 시 createdAt이 null이 되는 문제 해결, 알림 문제 해결

### DIFF
--- a/src/main/java/com/server/youthtalktalk/domain/post/entity/Post.java
+++ b/src/main/java/com/server/youthtalktalk/domain/post/entity/Post.java
@@ -12,6 +12,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -24,6 +25,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "post_type")
+@EntityListeners(AuditingEntityListener.class)
 public class Post{
 
     @Id


### PR DESCRIPTION
### ✏️ 이슈 번호
 - #51 

### ⛳ 작업 분류
- [x] createdAt이 null로 저장되는 문제 해결
- [x] 게시글 댓글 작성 시 알림 버그 해결 

### 🔨 작업 상세 내용
1. Post : createdAt 필드에 `@CreatedDate` 어노테이션 사용 후 `@EntityListeners(AuditingEntityListener.class)` 사용
- 원래는 BaseEntity를 상속받았는데, 이렇게 되면 조회 수 (view)가 증가할 때마다 수정일도 같이 갱신되는 문제가 발생합니다.
- 그래서 상속을 받지 않고, 게시글은 따로 필드를 추가했습니다.
- `@Modifying`을 jpa에서 사용하여 처리할 수도 있었지만, 이렇게 되면 **1차 캐싱과 DB간의 데이터가 일치하지 않는 문제**가 발생합니다.
- 이를 해결하려면 `clearAutomatically = true`를 사용해야하는데, 이는 **1차 캐싱을 모두 지우고 정합성을 맞추는 해결 방법**입니다.
- createdAt말고 다른 데이터들의 1차 캐싱까지 지운다는거 같아 **성능 저하가 크지 않을까 싶어** 그냥 updatedAt을 직접 지정했습니다.
- 원래 조회수 같은 경우는 **Redis캐싱도 많이 사용하는거 같습니다**. 저희가 아직 redis를 사용하고 있지 않아서 일단 위와같이 처리했습니다.

2. 알림 구현 시 `message.properties`파일이 필요합니다. 제가 로컬에서 dev 서버로 배포 시 이 파일이 포함되어 있었지만 다른 분들은 이 파일이 없는 채로 배포하게 돼서 에러가 발생했습니다. 서브 모듈에 올렸습니다.
